### PR TITLE
Issue #97: BUG: Cannot open review mode from PR menu

### DIFF
--- a/lua/gitflow/panels/review.lua
+++ b/lua/gitflow/panels/review.lua
@@ -349,18 +349,18 @@ local function build_comment_threads(comments)
 		end
 
 		local comment = {
-			id = c.id or 0,
+			id = tonumber(c.id) or 0,
 			path = c.path or "",
-			line = c.line or c.original_line,
-			original_line = c.original_line,
+			line = tonumber(c.line) or tonumber(c.original_line),
+			original_line = tonumber(c.original_line),
 			diff_hunk = c.diff_hunk,
 			body = c.body or "",
 			user = user,
-			in_reply_to_id = c.in_reply_to_id,
-			start_line = c.start_line,
+			in_reply_to_id = tonumber(c.in_reply_to_id),
+			start_line = tonumber(c.start_line),
 		}
 
-		if not c.in_reply_to_id then
+		if not comment.in_reply_to_id then
 			local thread = {
 				id = comment.id,
 				path = comment.path,
@@ -372,7 +372,7 @@ local function build_comment_threads(comments)
 			threads[#threads + 1] = thread
 			root_map[comment.id] = thread
 		else
-			local parent = root_map[c.in_reply_to_id]
+			local parent = root_map[comment.in_reply_to_id]
 			if parent then
 				parent.comments[#parent.comments + 1] = comment
 			else
@@ -402,8 +402,9 @@ local function render_thread_lines(thread)
 		thread.comments[1].user,
 		thread.path
 	)
-	if thread.comments[1].line then
-		header = header .. (":%d"):format(thread.comments[1].line)
+	local line = tonumber(thread.comments[1].line)
+	if line then
+		header = header .. (":%d"):format(line)
 	end
 	out[#out + 1] = header
 

--- a/scripts/test_stage5.lua
+++ b/scripts/test_stage5.lua
@@ -168,7 +168,7 @@ if [ "$#" -ge 2 ] && [ "$1" = "api" ]; then
       exit 0
       ;;
     *pulls/7/comments*)
-      echo '[{"id":101,"path":"lua/gitflow/commands.lua","line":11,"original_line":10,"diff_hunk":"@@ -10,2 +10,3 @@ local M = {}","body":"Consider renaming this variable","user":{"login":"reviewer1"},"in_reply_to_id":null},{"id":102,"path":"lua/gitflow/commands.lua","line":11,"original_line":10,"diff_hunk":"@@ -10,2 +10,3 @@ local M = {}","body":"Agreed, needs a better name","user":{"login":"reviewer2"},"in_reply_to_id":101}]'
+      echo '[{"id":"101","path":"lua/gitflow/commands.lua","line":"11","original_line":"10","diff_hunk":"@@ -10,2 +10,3 @@ local M = {}","body":"Consider renaming this variable","user":{"login":"reviewer1"},"in_reply_to_id":null},{"id":"102","path":"lua/gitflow/commands.lua","line":"11","original_line":"10","diff_hunk":"@@ -10,2 +10,3 @@ local M = {}","body":"Agreed, needs a better name","user":{"login":"reviewer2"},"in_reply_to_id":101}]'
       exit 0
       ;;
     *pulls/7/reviews*)
@@ -312,12 +312,23 @@ assert_true(
 	"review panel should show Review Comments section"
 )
 assert_true(
+	find_line(review_lines, "Review Comments (1 threads)") ~= nil,
+	"review panel should group reply comments under one thread"
+)
+assert_true(
 	find_line(review_lines, "@reviewer1") ~= nil,
 	"review panel should display reviewer1 comment"
 )
 assert_true(
 	find_line(review_lines, "@reviewer2") ~= nil,
 	"review panel should display reviewer2 reply"
+)
+assert_true(
+	find_line(
+		review_lines,
+		"@reviewer1 on lua/gitflow/commands.lua:11"
+	) ~= nil,
+	"review thread header should include numeric line suffix"
 )
 
 -- N2: verify file status indicators


### PR DESCRIPTION
## Summary
- normalize PR review comment numeric fields (`id`, `line`, `original_line`, `in_reply_to_id`, `start_line`) with `tonumber()` in `build_comment_threads()`
- use normalized `in_reply_to_id` for parent thread lookup so replies still attach when API values are not native Lua numbers
- defensively coerce the rendered thread line number before `:%d` formatting in `render_thread_lines()`
- extend Stage 5 smoke tests to cover mixed string/number comment IDs and string line fields, then assert both correct grouping and rendered `:11` header output

## Why
Opening review mode from the PR panel crashed when thread line values arrived in non-number types from `vim.json.decode`, because `%d` formatting expects a Lua number. The same coercion gap could also split reply threads due to mismatched map keys.

## Validation
- `nvim --headless -u NONE -l scripts/test_stage1.lua`
- `nvim --headless -u NONE -l scripts/test_stage2.lua`
- `nvim --headless -u NONE -l scripts/test_stage3.lua`
- `nvim --headless -u NONE -l scripts/test_stage4.lua`
- `nvim --headless -u NONE -l scripts/test_stage5.lua`
- `nvim --headless -u NONE -l scripts/test_stage6.lua`
- `nvim --headless -u NONE -l scripts/test_stage7.lua`

## Tradeoffs
- Coercion is done at the review panel boundary instead of `gh.json()` globally to keep the fix minimal and avoid changing types for unrelated GitHub payload consumers.

Closes #97
