### PR TITLE
Issue #92: Implement a git stash command that works from anywhere

### DIFF
--- a/lua/gitflow/commands.lua
+++ b/lua/gitflow/commands.lua
@@ -133,6 +133,50 @@ local function refresh_status_panel_if_open()
 	end
 end
 
+---@param output string
+---@return boolean
+local function output_mentions_no_local_changes(output)
+	return output:lower():find("no local changes to save", 1, true) ~= nil
+end
+
+---@param message string|nil
+local function run_stash_push(message)
+	git_stash.push({ message = message }, function(err, result)
+		if err then
+			show_error(err)
+			return
+		end
+
+		local output = result_message(result, "Created stash entry")
+		if output_mentions_no_local_changes(output) then
+			utils.notify(output, vim.log.levels.WARN)
+		else
+			show_info(output)
+		end
+
+		if stash_panel.is_open() then
+			stash_panel.refresh()
+		end
+		refresh_status_panel_if_open()
+	end)
+end
+
+local function prompt_and_run_stash_push()
+	vim.ui.input({
+		prompt = "Stash message (optional): ",
+	}, function(input)
+		if input == nil then
+			return
+		end
+
+		local message = vim.trim(input)
+		if message == "" then
+			message = nil
+		end
+		run_stash_push(message)
+	end)
+end
+
 ---@param amend boolean
 local function open_commit_prompt(amend)
 	git_status.fetch({}, function(err, _, grouped)
@@ -999,21 +1043,16 @@ local function register_builtin_subcommands(cfg)
 			end
 
 			if action == "push" then
-				local message = table.concat(ctx.args, " ", 3)
-				if message == "" then
-					message = nil
+				local has_message_arg = ctx.args[3] ~= nil
+				if has_message_arg then
+					local message = table.concat(ctx.args, " ", 3)
+					if vim.trim(message) == "" then
+						message = nil
+					end
+					run_stash_push(message)
+				else
+					prompt_and_run_stash_push()
 				end
-				git_stash.push({ message = message }, function(err, result)
-					if err then
-						show_error(err)
-						return
-					end
-					show_info(result_message(result, "Created stash entry"))
-					if stash_panel.is_open() then
-						stash_panel.refresh()
-					end
-					refresh_status_panel_if_open()
-				end)
 				return "Running git stash push..."
 			end
 
@@ -1928,6 +1967,7 @@ function M.setup(cfg)
 	vim.keymap.set("n", "<Plug>(GitflowDiff)", "<Cmd>Gitflow diff<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowLog)", "<Cmd>Gitflow log<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowStash)", "<Cmd>Gitflow stash list<CR>", { silent = true })
+	vim.keymap.set("n", "<Plug>(GitflowStashPush)", "<Cmd>Gitflow stash push<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowIssue)", "<Cmd>Gitflow issue list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowPr)", "<Cmd>Gitflow pr list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowLabel)", "<Cmd>Gitflow label list<CR>", { silent = true })
@@ -1949,6 +1989,7 @@ function M.setup(cfg)
 		diff = "<Plug>(GitflowDiff)",
 		log = "<Plug>(GitflowLog)",
 		stash = "<Plug>(GitflowStash)",
+		stash_push = "<Plug>(GitflowStashPush)",
 		issue = "<Plug>(GitflowIssue)",
 		pr = "<Plug>(GitflowPr)",
 		label = "<Plug>(GitflowLabel)",

--- a/lua/gitflow/config.lua
+++ b/lua/gitflow/config.lua
@@ -65,6 +65,7 @@ function M.defaults()
 			diff = "gd",
 			log = "gl",
 			stash = "gS",
+			stash_push = "gZ",
 			branch = "<leader>gb",
 			issue = "<leader>gI",
 			pr = "<leader>gR",


### PR DESCRIPTION
## Summary
- added a new default global keybinding `stash_push = gZ` that maps to `<Plug>(GitflowStashPush)` and executes `:Gitflow stash push` from any buffer
- updated stash push command flow so `:Gitflow stash push` prompts for an optional message when no message args are provided, while preserving direct-message behavior (`:Gitflow stash push my-message`)
- added warning handling for the no-op stash case (`No local changes to save`) so users get a WARN notification instead of INFO
- extended stash panel with an `S` keymap for prompted stash push, panel help text (`P/D/S/r/q`), and post-push refresh of stash/status panels
- updated stage 2 smoke tests for the new keymap/plug wiring, stash panel `S` keymap, and prompted stash push command path

## Why
Issue #92 asks for a stash action that can be run quickly from anywhere, including global/menu contexts. Existing behavior only exposed stash list globally (`gS`) and required extra steps to create a stash.

## Decisions and Tradeoffs
- kept `gS` unchanged for opening stash list and introduced `gZ` specifically for stash push to avoid breaking existing muscle memory
- used `vim.ui.input` for stash messages to align with existing prompt patterns and keep message optional
- preserved existing stash subcommand surface area instead of adding new top-level subcommands, minimizing architectural changes

## Validation
- `for t in $(ls scripts/test_stage*.lua | sort); do nvim --headless -u NONE -l "$t"; done`
