### PR TITLE
Issue #108: Follow-up: Consider extracting output_mentions_no_local_changes() into shared stash module

### DIFF
--- a/lua/gitflow/commands.lua
+++ b/lua/gitflow/commands.lua
@@ -133,12 +133,6 @@ local function refresh_status_panel_if_open()
 	end
 end
 
----@param output string
----@return boolean
-local function output_mentions_no_local_changes(output)
-	return output:lower():find("no local changes to save", 1, true) ~= nil
-end
-
 ---@param message string|nil
 local function run_stash_push(message)
 	git_stash.push({ message = message }, function(err, result)
@@ -148,7 +142,7 @@ local function run_stash_push(message)
 		end
 
 		local output = result_message(result, "Created stash entry")
-		if output_mentions_no_local_changes(output) then
+		if git_stash.output_mentions_no_local_changes(output) then
 			utils.notify(output, vim.log.levels.WARN)
 		else
 			show_info(output)

--- a/lua/gitflow/git/stash.lua
+++ b/lua/gitflow/git/stash.lua
@@ -122,4 +122,10 @@ function M.drop(index, opts, cb)
 	end)
 end
 
+---@param output string
+---@return boolean
+function M.output_mentions_no_local_changes(output)
+	return output:lower():find("no local changes to save", 1, true) ~= nil
+end
+
 return M

--- a/lua/gitflow/panels/stash.lua
+++ b/lua/gitflow/panels/stash.lua
@@ -120,16 +120,10 @@ local function output_or_default(result)
 	return output
 end
 
----@param output string
----@return boolean
-local function output_mentions_no_local_changes(output)
-	return output:lower():find("no local changes to save", 1, true) ~= nil
-end
-
 ---@param result GitflowGitResult
 local function notify_push_result(result)
 	local output = output_or_default(result)
-	if output_mentions_no_local_changes(output) then
+	if git_stash.output_mentions_no_local_changes(output) then
 		utils.notify(output, vim.log.levels.WARN)
 		return
 	end


### PR DESCRIPTION
## Summary
- moved stash output helper `output_mentions_no_local_changes(output)` into `lua/gitflow/git/stash.lua` as `M.output_mentions_no_local_changes`
- removed duplicate local helper definitions from `lua/gitflow/commands.lua` and `lua/gitflow/panels/stash.lua`
- updated both stash push notification call sites to use the shared module function

## Why
- resolves issue #108 by eliminating duplicated stash-specific output parsing logic
- keeps behavior unchanged while reducing maintenance overhead for this helper

## Validation
- ran full stage test sweep in this repo snapshot:
  - `scripts/test_stage1.lua`
  - `scripts/test_stage2.lua`
  - `scripts/test_stage3.lua`
  - `scripts/test_stage4.lua`
  - `scripts/test_stage5.lua`
  - `scripts/test_stage6.lua`
  - `scripts/test_stage7.lua`
  - `scripts/test_stage8_highlights.lua`
