### PR TITLE
Issue #123: Make a diagram included in the README.md for the architecture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ flowchart TB
   PANELS --> GITMOD
   PANELS --> GHMOD
   UI -->|Lua API calls| NVAPI
-  GITMOD -->|Process I/O (stdout/stderr)| GITCLI
-  GHMOD -->|CLI JSON over stdout| GHCLI
-  GHCLI -->|HTTPS REST/GraphQL| GHAPI
+  GITMOD -->|Process IO stdout and stderr| GITCLI
+  GHMOD -->|CLI JSON output| GHCLI
+  GHCLI -->|HTTPS REST and GraphQL| GHAPI
 ```
 
 ## Basic Configuration


### PR DESCRIPTION
## Summary
- add a new `Architecture` section to `README.md` directly after the intro
- include a Mermaid flowchart that maps the plugin's runtime layers and module boundaries
- document external integrations and protocols: Neovim API calls, process I/O to `git`, CLI JSON to `gh`, and HTTPS to GitHub API

## Why
The issue asked for an architecture diagram in the README. This provides a GitHub-rendered, text-maintainable diagram that reflects the repository's real stack and component relationships.

## Decisions / Tradeoffs
- used Mermaid instead of image assets to avoid binary file maintenance and keep edits reviewable in diffs
- modeled the actual technologies used by this repo (Lua/Neovim + `git`/`gh`) rather than generic Python/FastAPI components from the original issue text
- kept scope documentation-only with no runtime behavior changes