### PR TITLE
Issue #100: [Phase 3: Stage 8] Statusline Component

### DIFF
--- a/lua/gitflow/init.lua
+++ b/lua/gitflow/init.lua
@@ -3,13 +3,36 @@ local commands = require("gitflow.commands")
 local gh = require("gitflow.gh")
 local highlights = require("gitflow.highlights")
 local signs = require("gitflow.signs")
-local statusline = require("gitflow.statusline")
 
 local M = {}
+local statusline_module = nil
+
+---@return table|nil
+local function load_statusline_module()
+	if statusline_module ~= nil then
+		return statusline_module
+	end
+
+	local ok, module = pcall(require, "gitflow.statusline")
+	if not ok or type(module) ~= "table" then
+		return nil
+	end
+
+	statusline_module = module
+	return statusline_module
+end
 
 ---@type boolean
 M.initialized = false
-M.statusline = statusline.get
+
+---@return string
+function M.statusline()
+	local statusline = load_statusline_module()
+	if statusline == nil or type(statusline.get) ~= "function" then
+		return ""
+	end
+	return statusline.get()
+end
 
 ---@param opts table|nil
 ---@return GitflowConfig
@@ -18,8 +41,13 @@ function M.setup(opts)
 	highlights.setup(cfg.highlights)
 	commands.setup(cfg)
 	signs.setup(cfg)
-	statusline.setup()
-	statusline.refresh()
+	local statusline = load_statusline_module()
+	if statusline ~= nil and type(statusline.setup) == "function" then
+		statusline.setup()
+	end
+	if statusline ~= nil and type(statusline.refresh) == "function" then
+		statusline.refresh()
+	end
 	gh.check_prerequisites({ notify = true })
 	M.initialized = true
 	return cfg

--- a/lua/gitflow/statusline.lua
+++ b/lua/gitflow/statusline.lua
@@ -79,14 +79,26 @@ local function notify_waiters(value)
 	end
 end
 
+local function redraw_statusline()
+	vim.schedule(function()
+		pcall(vim.cmd, "redrawstatus")
+	end)
+end
+
 ---@param value string
 ---@param cwd string
 local function finish_refresh(value, cwd)
-	M.state.cache = value or ""
+	local normalized = value or ""
+	local changed = M.state.cache ~= normalized or M.state.cwd ~= cwd or not M.state.warmed
+
+	M.state.cache = normalized
 	M.state.cwd = cwd
 	M.state.warmed = true
 	M.state.updating = false
 	notify_waiters(M.state.cache)
+	if changed then
+		redraw_statusline()
+	end
 
 	if M.state.pending then
 		M.state.pending = false


### PR DESCRIPTION
Closes #100

## What changed
- Added `lua/gitflow/statusline.lua` with a cached synchronous getter (`get`) and async refresh pipeline (`refresh`) that builds a plain statusline string from:
  - current branch
  - upstream divergence (`↑ahead ↓behind`)
  - dirty marker (`*`)
- Added refresh hooks in a dedicated `GitflowStatusline` augroup for:
  - `FocusGained`
  - `BufWritePost`
  - `User` autocmd pattern `GitflowPostOperation`
- Wired public API export in `lua/gitflow/init.lua` as `require("gitflow").statusline`, and initialized statusline setup/initial refresh during `gitflow.setup()`.
- Added `scripts/test_stage8_statusline.lua` covering:
  - plain string return type
  - branch + ahead/behind formatting
  - dirty indicator updates on `BufWritePost`
  - refresh on `GitflowPostOperation`
  - refresh on `FocusGained`
  - empty string outside git repositories

## Why
- Neovim statusline providers must return synchronously, so this introduces a cached getter with background refresh to keep rendering compatible with native statusline/lualine/heirline while avoiding repeated git calls.

## Key decisions / tradeoffs
- Used existing `User GitflowPostOperation` event wiring instead of introducing a new callback registry, keeping integration minimal and aligned with current Stage 8 event patterns.
- Implemented a lightweight in-flight + pending refresh guard to avoid redundant concurrent git calls during rapid event bursts.
- If upstream divergence cannot be resolved, statusline still returns branch/dirty info instead of failing noisy or hard.

## Validation
- `nvim --headless -u NONE -l scripts/test_stage8_statusline.lua`
- `for t in $(ls scripts/test_stage*.lua | sort); do nvim --headless -u NONE -l "$t"; done`
