### PR TITLE
Issue #101: [Phase 4: Stage 8] Floating Window Styling

### DIFF
--- a/lua/gitflow/commands.lua
+++ b/lua/gitflow/commands.lua
@@ -33,6 +33,7 @@ local label_completion = require("gitflow.completion.labels")
 ---@field panel_window integer|nil
 
 local M = {}
+local MAIN_FLOAT_FOOTER = ":Gitflow status  :Gitflow branch  :Gitflow prs  :Gitflow issues"
 
 ---@type table<string, GitflowSubcommand>
 M.subcommands = {}
@@ -94,6 +95,9 @@ local function open_panel(cfg)
 			height = cfg.ui.float.height,
 			border = cfg.ui.float.border,
 			title = cfg.ui.float.title,
+			title_pos = cfg.ui.float.title_pos,
+			footer = cfg.ui.float.footer and MAIN_FLOAT_FOOTER or nil,
+			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.panel_window = nil
 			end,

--- a/lua/gitflow/config.lua
+++ b/lua/gitflow/config.lua
@@ -9,6 +9,9 @@ local utils = require("gitflow.utils")
 ---@field height number
 ---@field border string|string[]
 ---@field title string
+---@field title_pos "left"|"center"|"right"
+---@field footer boolean
+---@field footer_pos "left"|"center"|"right"
 
 ---@class GitflowUiConfig
 ---@field default_layout "split"|"float"
@@ -92,6 +95,9 @@ function M.defaults()
 				height = 0.7,
 				border = "rounded",
 				title = "Gitflow",
+				title_pos = "center",
+				footer = true,
+				footer_pos = "center",
 			},
 		},
 		behavior = {
@@ -176,11 +182,52 @@ local function validate_ui(config)
 	if type(float.height) ~= "number" or float.height <= 0 then
 		error("gitflow config error: ui.float.height must be a positive number", 3)
 	end
-	if type(float.border) ~= "string" and type(float.border) ~= "table" then
+	local valid_border_styles = {
+		none = true,
+		single = true,
+		double = true,
+		rounded = true,
+		solid = true,
+		shadow = true,
+	}
+	if type(float.border) == "string" then
+		if not valid_border_styles[float.border] then
+			error(
+				"gitflow config error: ui.float.border must be one of "
+					.. "'none', 'single', 'double', 'rounded', 'solid', or 'shadow'",
+				3
+			)
+		end
+	elseif type(float.border) == "table" then
+		for key, value in pairs(float.border) do
+			if type(value) ~= "string" then
+				error(
+					("gitflow config error: ui.float.border[%s] must be a string"):format(
+						vim.inspect(key)
+					),
+					3
+				)
+			end
+		end
+	else
 		error("gitflow config error: ui.float.border must be a string or string[]", 3)
 	end
 	if not utils.is_non_empty_string(float.title) then
 		error("gitflow config error: ui.float.title must be a non-empty string", 3)
+	end
+	local valid_positions = {
+		left = true,
+		center = true,
+		right = true,
+	}
+	if not valid_positions[float.title_pos] then
+		error("gitflow config error: ui.float.title_pos must be 'left', 'center', or 'right'", 3)
+	end
+	if type(float.footer) ~= "boolean" then
+		error("gitflow config error: ui.float.footer must be a boolean", 3)
+	end
+	if not valid_positions[float.footer_pos] then
+		error("gitflow config error: ui.float.footer_pos must be 'left', 'center', or 'right'", 3)
 	end
 end
 

--- a/lua/gitflow/panels/branch.lua
+++ b/lua/gitflow/panels/branch.lua
@@ -11,6 +11,10 @@ local git_branch = require("gitflow.git.branch")
 
 local M = {}
 local BRANCH_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_branch_hl")
+local BRANCH_FLOAT_TITLE = "Gitflow Branches"
+local BRANCH_FLOAT_FOOTER =
+	"<CR> switch  c create  d delete  D force delete  r rename"
+	.. "  R refresh  f fetch  q close"
 
 ---@type GitflowBranchPanelState
 M.state = {
@@ -49,15 +53,32 @@ local function ensure_window(cfg)
 		return
 	end
 
-	M.state.winid = ui.window.open_split({
-		name = "branch",
-		bufnr = bufnr,
-		orientation = cfg.ui.split.orientation,
-		size = cfg.ui.split.size,
-		on_close = function()
-			M.state.winid = nil
-		end,
-	})
+	if cfg.ui.default_layout == "float" then
+		M.state.winid = ui.window.open_float({
+			name = "branch",
+			bufnr = bufnr,
+			width = cfg.ui.float.width,
+			height = cfg.ui.float.height,
+			border = cfg.ui.float.border,
+			title = BRANCH_FLOAT_TITLE,
+			title_pos = cfg.ui.float.title_pos,
+			footer = cfg.ui.float.footer and BRANCH_FLOAT_FOOTER or nil,
+			footer_pos = cfg.ui.float.footer_pos,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	else
+		M.state.winid = ui.window.open_split({
+			name = "branch",
+			bufnr = bufnr,
+			orientation = cfg.ui.split.orientation,
+			size = cfg.ui.split.size,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	end
 
 	vim.keymap.set("n", "<CR>", function()
 		M.switch_under_cursor()

--- a/lua/gitflow/panels/conflict.lua
+++ b/lua/gitflow/panels/conflict.lua
@@ -23,6 +23,9 @@ local conflict_view = require("gitflow.ui.conflict")
 
 local M = {}
 local CONFLICT_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_conflict_hl")
+local CONFLICT_FLOAT_TITLE = "Gitflow Conflicts"
+local CONFLICT_FLOAT_FOOTER =
+	"<CR> open 3-way  r refresh  C continue  A abort  q close"
 
 ---@type GitflowConflictPanelState
 M.state = {
@@ -96,15 +99,32 @@ local function ensure_window(cfg)
 		return
 	end
 
-	M.state.winid = ui.window.open_split({
-		name = "conflict",
-		bufnr = bufnr,
-		orientation = cfg.ui.split.orientation,
-		size = cfg.ui.split.size,
-		on_close = function()
-			M.state.winid = nil
-		end,
-	})
+	if cfg.ui.default_layout == "float" then
+		M.state.winid = ui.window.open_float({
+			name = "conflict",
+			bufnr = bufnr,
+			width = cfg.ui.float.width,
+			height = cfg.ui.float.height,
+			border = cfg.ui.float.border,
+			title = CONFLICT_FLOAT_TITLE,
+			title_pos = cfg.ui.float.title_pos,
+			footer = cfg.ui.float.footer and CONFLICT_FLOAT_FOOTER or nil,
+			footer_pos = cfg.ui.float.footer_pos,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	else
+		M.state.winid = ui.window.open_split({
+			name = "conflict",
+			bufnr = bufnr,
+			orientation = cfg.ui.split.orientation,
+			size = cfg.ui.split.size,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	end
 
 	vim.keymap.set("n", "<CR>", function()
 		M.open_under_cursor()

--- a/lua/gitflow/panels/diff.lua
+++ b/lua/gitflow/panels/diff.lua
@@ -10,6 +10,8 @@ local git_branch = require("gitflow.git.branch")
 
 local M = {}
 local DIFF_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_diff_hl")
+local DIFF_FLOAT_TITLE = "Gitflow Diff"
+local DIFF_FLOAT_FOOTER = "r refresh  q close"
 
 ---@type GitflowDiffPanelState
 M.state = {
@@ -64,15 +66,32 @@ local function ensure_window(cfg)
 		return
 	end
 
-	M.state.winid = ui.window.open_split({
-		name = "diff",
-		bufnr = bufnr,
-		orientation = cfg.ui.split.orientation,
-		size = cfg.ui.split.size,
-		on_close = function()
-			M.state.winid = nil
-		end,
-	})
+	if cfg.ui.default_layout == "float" then
+		M.state.winid = ui.window.open_float({
+			name = "diff",
+			bufnr = bufnr,
+			width = cfg.ui.float.width,
+			height = cfg.ui.float.height,
+			border = cfg.ui.float.border,
+			title = DIFF_FLOAT_TITLE,
+			title_pos = cfg.ui.float.title_pos,
+			footer = cfg.ui.float.footer and DIFF_FLOAT_FOOTER or nil,
+			footer_pos = cfg.ui.float.footer_pos,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	else
+		M.state.winid = ui.window.open_split({
+			name = "diff",
+			bufnr = bufnr,
+			orientation = cfg.ui.split.orientation,
+			size = cfg.ui.split.size,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	end
 
 	vim.keymap.set("n", "q", function()
 		M.close()

--- a/lua/gitflow/panels/log.lua
+++ b/lua/gitflow/panels/log.lua
@@ -14,6 +14,8 @@ local git_branch = require("gitflow.git.branch")
 ---@field opts GitflowLogPanelOpts
 
 local M = {}
+local LOG_FLOAT_TITLE = "Gitflow Log"
+local LOG_FLOAT_FOOTER = "<CR> open commit diff  r refresh  q close"
 
 ---@type GitflowLogPanelState
 M.state = {
@@ -42,15 +44,32 @@ local function ensure_window(cfg)
 		return
 	end
 
-	M.state.winid = ui.window.open_split({
-		name = "log",
-		bufnr = bufnr,
-		orientation = cfg.ui.split.orientation,
-		size = cfg.ui.split.size,
-		on_close = function()
-			M.state.winid = nil
-		end,
-	})
+	if cfg.ui.default_layout == "float" then
+		M.state.winid = ui.window.open_float({
+			name = "log",
+			bufnr = bufnr,
+			width = cfg.ui.float.width,
+			height = cfg.ui.float.height,
+			border = cfg.ui.float.border,
+			title = LOG_FLOAT_TITLE,
+			title_pos = cfg.ui.float.title_pos,
+			footer = cfg.ui.float.footer and LOG_FLOAT_FOOTER or nil,
+			footer_pos = cfg.ui.float.footer_pos,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	else
+		M.state.winid = ui.window.open_split({
+			name = "log",
+			bufnr = bufnr,
+			orientation = cfg.ui.split.orientation,
+			size = cfg.ui.split.size,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	end
 
 	vim.keymap.set("n", "<CR>", function()
 		M.open_commit_under_cursor()

--- a/lua/gitflow/panels/palette.lua
+++ b/lua/gitflow/panels/palette.lua
@@ -23,6 +23,8 @@ local utils = require("gitflow.utils")
 
 local M = {}
 local SELECTION_HIGHLIGHT = "GitflowPaletteSelection"
+local PALETTE_PROMPT_FOOTER = "<CR> select  <Esc> close  <Down>/<Up> navigate"
+local PALETTE_LIST_FOOTER = "<CR> select  j/k move  q close"
 
 ---@type GitflowPalettePanelState
 M.state = {
@@ -497,7 +499,9 @@ function M.open(cfg, entries, on_select)
 		col = col,
 		border = cfg.ui.float.border,
 		title = "Gitflow Palette Query",
-		title_pos = "left",
+		title_pos = cfg.ui.float.title_pos,
+		footer = cfg.ui.float.footer and PALETTE_PROMPT_FOOTER or nil,
+		footer_pos = cfg.ui.float.footer_pos,
 	})
 
 	M.state.list_winid = ui.window.open_float({
@@ -509,7 +513,9 @@ function M.open(cfg, entries, on_select)
 		col = col,
 		border = cfg.ui.float.border,
 		title = "Gitflow Palette",
-		title_pos = "left",
+		title_pos = cfg.ui.float.title_pos,
+		footer = cfg.ui.float.footer and PALETTE_LIST_FOOTER or nil,
+		footer_pos = cfg.ui.float.footer_pos,
 	})
 
 	vim.api.nvim_set_option_value("wrap", false, { win = M.state.prompt_winid })

--- a/lua/gitflow/panels/review.lua
+++ b/lua/gitflow/panels/review.lua
@@ -63,6 +63,10 @@ local gh_prs = require("gitflow.gh.prs")
 
 local M = {}
 local REVIEW_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_review_hl")
+local REVIEW_FLOAT_FOOTER =
+	"]f/[f files  ]c/[c hunks  c comment  S submit"
+	.. "  a approve  x changes  R reply"
+	.. "  <leader>t toggle  <leader>b back  r refresh  q close"
 
 ---@type GitflowPrReviewPanelState
 M.state = {
@@ -103,6 +107,11 @@ local function ensure_window(cfg)
 	-- B3: save current window so we can restore it on close
 	M.state.prev_winid = vim.api.nvim_get_current_win()
 
+	local title = "Gitflow PR Review"
+	if M.state.pr_number then
+		title = ("Gitflow PR Review #%d"):format(M.state.pr_number)
+	end
+
 	-- B3: fullscreen floating window that overlays the editor
 	M.state.winid = ui.window.open_float({
 		name = "review",
@@ -111,7 +120,11 @@ local function ensure_window(cfg)
 		height = 1.0,
 		row = 0,
 		col = 0,
-		border = "none",
+		border = cfg.ui.float.border,
+		title = title,
+		title_pos = cfg.ui.float.title_pos,
+		footer = cfg.ui.float.footer and REVIEW_FLOAT_FOOTER or nil,
+		footer_pos = cfg.ui.float.footer_pos,
 		on_close = function()
 			M.state.winid = nil
 		end,

--- a/lua/gitflow/panels/stash.lua
+++ b/lua/gitflow/panels/stash.lua
@@ -12,6 +12,8 @@ local status_panel = require("gitflow.panels.status")
 ---@field cfg GitflowConfig|nil
 
 local M = {}
+local STASH_FLOAT_TITLE = "Gitflow Stash"
+local STASH_FLOAT_FOOTER = "P pop  D drop  S stash  r refresh  q close"
 
 ---@type GitflowStashPanelState
 M.state = {
@@ -45,15 +47,32 @@ local function ensure_window(cfg)
 		return
 	end
 
-	M.state.winid = ui.window.open_split({
-		name = "stash",
-		bufnr = bufnr,
-		orientation = cfg.ui.split.orientation,
-		size = cfg.ui.split.size,
-		on_close = function()
-			M.state.winid = nil
-		end,
-	})
+	if cfg.ui.default_layout == "float" then
+		M.state.winid = ui.window.open_float({
+			name = "stash",
+			bufnr = bufnr,
+			width = cfg.ui.float.width,
+			height = cfg.ui.float.height,
+			border = cfg.ui.float.border,
+			title = STASH_FLOAT_TITLE,
+			title_pos = cfg.ui.float.title_pos,
+			footer = cfg.ui.float.footer and STASH_FLOAT_FOOTER or nil,
+			footer_pos = cfg.ui.float.footer_pos,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	else
+		M.state.winid = ui.window.open_split({
+			name = "stash",
+			bufnr = bufnr,
+			orientation = cfg.ui.split.orientation,
+			size = cfg.ui.split.size,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	end
 
 	vim.keymap.set("n", "P", function()
 		M.pop_under_cursor()

--- a/lua/gitflow/panels/status.lua
+++ b/lua/gitflow/panels/status.lua
@@ -37,6 +37,10 @@ local conflict_panel = require("gitflow.panels.conflict")
 
 local M = {}
 local STATUS_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_status_hl")
+local STATUS_FLOAT_TITLE = "Gitflow Status"
+local STATUS_FLOAT_FOOTER =
+	"s stage  u unstage  a stage all  A unstage all  cc commit  dd diff"
+	.. "  cx conflicts  p push  X revert  r refresh  q close"
 
 ---@type GitflowStatusPanelState
 M.state = {
@@ -188,16 +192,34 @@ local function ensure_window(cfg)
 		return
 	end
 
-	M.state.winid = ui.window.open_split({
-		name = "status",
-		bufnr = bufnr,
-		orientation = cfg.ui.split.orientation,
-		size = cfg.ui.split.size,
-		on_close = function()
-			M.state.winid = nil
-			M.state.active = false
-		end,
-	})
+	if cfg.ui.default_layout == "float" then
+		M.state.winid = ui.window.open_float({
+			name = "status",
+			bufnr = bufnr,
+			width = cfg.ui.float.width,
+			height = cfg.ui.float.height,
+			border = cfg.ui.float.border,
+			title = STATUS_FLOAT_TITLE,
+			title_pos = cfg.ui.float.title_pos,
+			footer = cfg.ui.float.footer and STATUS_FLOAT_FOOTER or nil,
+			footer_pos = cfg.ui.float.footer_pos,
+			on_close = function()
+				M.state.winid = nil
+				M.state.active = false
+			end,
+		})
+	else
+		M.state.winid = ui.window.open_split({
+			name = "status",
+			bufnr = bufnr,
+			orientation = cfg.ui.split.orientation,
+			size = cfg.ui.split.size,
+			on_close = function()
+				M.state.winid = nil
+				M.state.active = false
+			end,
+		})
+	end
 
 	vim.keymap.set("n", "s", function()
 		M.stage_under_cursor()

--- a/lua/gitflow/ui/window.lua
+++ b/lua/gitflow/ui/window.lua
@@ -16,6 +16,8 @@
 ---@field border? string|string[]
 ---@field title? string
 ---@field title_pos? "left"|"center"|"right"
+---@field footer? string|string[]
+---@field footer_pos? "left"|"center"|"right"
 ---@field enter? boolean
 ---@field on_close? fun(winid: integer)
 
@@ -137,12 +139,16 @@ function M.open_float(opts)
 		win_opts.title = opts.title
 		win_opts.title_pos = opts.title_pos or "center"
 	end
+	if opts.footer and vim.fn.has("nvim-0.10") == 1 then
+		win_opts.footer = opts.footer
+		win_opts.footer_pos = opts.footer_pos or "center"
+	end
 	local winid = vim.api.nvim_open_win(
 		opts.bufnr, opts.enter ~= false, win_opts
 	)
 	vim.api.nvim_set_option_value(
 		"winhighlight",
-		"FloatBorder:GitflowBorder,FloatTitle:GitflowTitle",
+		"FloatBorder:GitflowBorder,FloatTitle:GitflowTitle,FloatFooter:GitflowFooter",
 		{ win = winid }
 	)
 

--- a/scripts/test_stage8_windows.lua
+++ b/scripts/test_stage8_windows.lua
@@ -1,0 +1,309 @@
+local script_path = debug.getinfo(1, "S").source:sub(2)
+local project_root = vim.fn.fnamemodify(script_path, ":p:h:h")
+vim.opt.runtimepath:append(project_root)
+
+local function assert_true(condition, message)
+	if not condition then
+		error(message, 2)
+	end
+end
+
+local function assert_equals(actual, expected, message)
+	if actual ~= expected then
+		error(
+			("%s (expected=%s, actual=%s)"):format(
+				message,
+				vim.inspect(expected),
+				vim.inspect(actual)
+			),
+			2
+		)
+	end
+end
+
+local function assert_contains(text, needle, message)
+	assert_true(type(text) == "string", message)
+	assert_true(text:find(needle, 1, true) ~= nil, message)
+end
+
+local config = require("gitflow.config")
+local window = require("gitflow.ui.window")
+local ui = require("gitflow.ui")
+
+local defaults = config.defaults()
+assert_equals(defaults.ui.float.title_pos, "center", "float.title_pos default should be center")
+assert_equals(defaults.ui.float.footer, true, "float.footer default should be true")
+assert_equals(defaults.ui.float.footer_pos, "center", "float.footer_pos default should be center")
+
+local invalid_title_pos = vim.deepcopy(defaults)
+invalid_title_pos.ui.float.title_pos = "middle"
+local ok_title_pos, err_title_pos = pcall(config.validate, invalid_title_pos)
+assert_true(not ok_title_pos, "config.validate should reject invalid float.title_pos")
+assert_contains(tostring(err_title_pos), "title_pos", "title_pos error should mention title_pos")
+
+local invalid_footer = vim.deepcopy(defaults)
+invalid_footer.ui.float.footer = "yes"
+local ok_footer, err_footer = pcall(config.validate, invalid_footer)
+assert_true(not ok_footer, "config.validate should reject non-boolean float.footer")
+assert_contains(
+	tostring(err_footer),
+	"ui.float.footer",
+	"footer error should mention ui.float.footer"
+)
+
+local invalid_footer_pos = vim.deepcopy(defaults)
+invalid_footer_pos.ui.float.footer_pos = "middle"
+local ok_footer_pos, err_footer_pos = pcall(config.validate, invalid_footer_pos)
+assert_true(not ok_footer_pos, "config.validate should reject invalid float.footer_pos")
+assert_contains(
+	tostring(err_footer_pos),
+	"footer_pos",
+	"footer_pos error should mention footer_pos"
+)
+
+local invalid_border = vim.deepcopy(defaults)
+invalid_border.ui.float.border = "bad-border"
+local ok_border, err_border = pcall(config.validate, invalid_border)
+assert_true(not ok_border, "config.validate should reject invalid string float.border")
+assert_contains(
+	tostring(err_border),
+	"ui.float.border",
+	"border error should mention ui.float.border"
+)
+
+for _, border in ipairs({ "single", "double", "rounded", "shadow" }) do
+	local cfg = config.setup({
+		ui = {
+			float = {
+				border = border,
+			},
+		},
+	})
+	assert_equals(cfg.ui.float.border, border, ("config should retain border '%s'"):format(border))
+	local bufnr = vim.api.nvim_create_buf(false, true)
+	local winid = window.open_float({
+		bufnr = bufnr,
+		width = 0.4,
+		height = 0.3,
+		border = border,
+		title = "Stage 8",
+		title_pos = "right",
+		footer = "Hints",
+		footer_pos = "left",
+	})
+	assert_true(
+		vim.api.nvim_win_is_valid(winid),
+		("open_float should open with border '%s'"):format(border)
+	)
+	window.close(winid)
+	vim.api.nvim_buf_delete(bufnr, { force = true })
+end
+
+local bufnr = vim.api.nvim_create_buf(false, true)
+local winid = window.open_float({
+	bufnr = bufnr,
+	width = 0.5,
+	height = 0.4,
+	border = "double",
+	title = "Window Title",
+	title_pos = "right",
+	footer = "Footer Hints",
+	footer_pos = "left",
+})
+local win_cfg = vim.api.nvim_win_get_config(winid)
+assert_equals(win_cfg.title_pos, "right", "open_float should pass title_pos")
+assert_equals(win_cfg.footer_pos, "left", "open_float should pass footer_pos")
+assert_true(
+	type(win_cfg.title) == "table" and win_cfg.title[1][1] == "Window Title",
+	"title text should be set"
+)
+assert_true(
+	type(win_cfg.footer) == "table" and win_cfg.footer[1][1] == "Footer Hints",
+	"footer text should be set on Neovim 0.10+"
+)
+local winhighlight = vim.api.nvim_get_option_value("winhighlight", { win = winid })
+assert_contains(
+	winhighlight,
+	"FloatFooter:GitflowFooter",
+	"open_float should map FloatFooter highlight"
+)
+window.close(winid)
+vim.api.nvim_buf_delete(bufnr, { force = true })
+
+local original_has = vim.fn.has
+vim.fn.has = function(feature)
+	if feature == "nvim-0.10" then
+		return 0
+	end
+	return original_has(feature)
+end
+
+local old_bufnr = vim.api.nvim_create_buf(false, true)
+local old_winid = window.open_float({
+	bufnr = old_bufnr,
+	width = 0.4,
+	height = 0.3,
+	title = "Legacy",
+	footer = "Ignored",
+})
+local old_cfg = vim.api.nvim_win_get_config(old_winid)
+assert_true(old_cfg.footer == nil, "open_float should omit footer on Neovim < 0.10")
+window.close(old_winid)
+vim.api.nvim_buf_delete(old_bufnr, { force = true })
+vim.fn.has = original_has
+
+local float_cfg = config.setup({
+	ui = {
+		default_layout = "float",
+		float = {
+			width = 0.65,
+			height = 0.55,
+			border = "rounded",
+			title = "Gitflow",
+			title_pos = "right",
+			footer = true,
+			footer_pos = "left",
+		},
+	},
+})
+
+local captured = {}
+local original_open_float = ui.window.open_float
+ui.window.open_float = function(opts)
+	captured[#captured + 1] = vim.deepcopy(opts)
+	return original_open_float(opts)
+end
+
+local function find_capture(start_index, name)
+	for i = #captured, start_index + 1, -1 do
+		if captured[i].name == name then
+			return captured[i]
+		end
+	end
+	return nil
+end
+
+local function assert_float_panel_capture(start_index, name)
+	local opts = find_capture(start_index, name)
+	assert_true(opts ~= nil, ("expected float capture for panel '%s'"):format(name))
+	assert_true(type(opts.title) == "string" and opts.title ~= "", "float panels should provide title")
+	assert_equals(
+		opts.title_pos,
+		float_cfg.ui.float.title_pos,
+		("panel '%s' should pass configured title_pos"):format(name)
+	)
+	assert_true(
+		type(opts.footer) == "string" and opts.footer ~= "",
+		"float panels should provide footer"
+	)
+	assert_equals(
+		opts.footer_pos,
+		float_cfg.ui.float.footer_pos,
+		("panel '%s' should pass configured footer_pos"):format(name)
+	)
+	assert_equals(opts.border, float_cfg.ui.float.border, "float panels should use configured border")
+end
+
+local status_panel = require("gitflow.panels.status")
+local branch_panel = require("gitflow.panels.branch")
+local log_panel = require("gitflow.panels.log")
+local stash_panel = require("gitflow.panels.stash")
+local conflict_panel = require("gitflow.panels.conflict")
+local issues_panel = require("gitflow.panels.issues")
+local prs_panel = require("gitflow.panels.prs")
+local review_panel = require("gitflow.panels.review")
+local diff_panel = require("gitflow.panels.diff")
+local palette_panel = require("gitflow.panels.palette")
+
+local original_status_refresh = status_panel.refresh
+status_panel.refresh = function() end
+local start = #captured
+status_panel.open(float_cfg, {})
+assert_float_panel_capture(start, "status")
+status_panel.close()
+status_panel.refresh = original_status_refresh
+
+local original_branch_refresh = branch_panel.refresh
+branch_panel.refresh = function() end
+start = #captured
+branch_panel.open(float_cfg)
+assert_float_panel_capture(start, "branch")
+branch_panel.close()
+branch_panel.refresh = original_branch_refresh
+
+local original_log_refresh = log_panel.refresh
+log_panel.refresh = function() end
+start = #captured
+log_panel.open(float_cfg, {})
+assert_float_panel_capture(start, "log")
+log_panel.close()
+log_panel.refresh = original_log_refresh
+
+local original_stash_refresh = stash_panel.refresh
+stash_panel.refresh = function() end
+start = #captured
+stash_panel.open(float_cfg)
+assert_float_panel_capture(start, "stash")
+stash_panel.close()
+stash_panel.refresh = original_stash_refresh
+
+local original_conflict_refresh = conflict_panel.refresh
+conflict_panel.refresh = function() end
+start = #captured
+conflict_panel.open(float_cfg, {})
+assert_float_panel_capture(start, "conflict")
+conflict_panel.close()
+conflict_panel.refresh = original_conflict_refresh
+
+local original_issues_refresh = issues_panel.refresh
+issues_panel.refresh = function() end
+start = #captured
+issues_panel.open(float_cfg, {})
+assert_float_panel_capture(start, "issues")
+issues_panel.close()
+issues_panel.refresh = original_issues_refresh
+
+local original_prs_refresh = prs_panel.refresh
+prs_panel.refresh = function() end
+start = #captured
+prs_panel.open(float_cfg, {})
+assert_float_panel_capture(start, "prs")
+prs_panel.close()
+prs_panel.refresh = original_prs_refresh
+
+local original_review_refresh = review_panel.refresh
+review_panel.refresh = function() end
+start = #captured
+review_panel.open(float_cfg, 7)
+assert_float_panel_capture(start, "review")
+review_panel.close()
+review_panel.refresh = original_review_refresh
+
+local git_branch = require("gitflow.git.branch")
+local git_diff = require("gitflow.git.diff")
+local original_branch_current = git_branch.current
+local original_diff_get = git_diff.get
+git_branch.current = function(_, cb)
+	cb(nil, "main")
+end
+git_diff.get = function(_, cb)
+	cb(nil, "")
+end
+start = #captured
+diff_panel.open(float_cfg, { staged = true })
+assert_float_panel_capture(start, "diff")
+diff_panel.close()
+git_branch.current = original_branch_current
+git_diff.get = original_diff_get
+
+start = #captured
+palette_panel.open(float_cfg, {
+	{ name = "status", description = "Open status panel", category = "Git", keybinding = "gs" },
+}, function(_) end)
+assert_float_panel_capture(start, "palette_prompt")
+assert_float_panel_capture(start, "palette_list")
+palette_panel.close()
+
+ui.window.open_float = original_open_float
+
+print("Stage 8 windows tests passed")


### PR DESCRIPTION
Closes #101

## What changed
- Extended `ui.float` defaults/validation in `lua/gitflow/config.lua` with `title_pos`, `footer`, and `footer_pos`.
- Extended `lua/gitflow/ui/window.lua` float support for `footer`/`footer_pos`, including `nvim-0.10+` guard and `FloatFooter:GitflowFooter` winhighlight mapping.
- Updated float-window panel wiring to pass border/title/footer metadata for Stage 8 scope:
  - `status`, `branch`, `diff`, `issues`, `prs`, `review`, `log`, `stash`, `conflict`, and command palette prompt/list windows.
- Updated main command panel float open path to honor configured `title_pos` and footer metadata.
- Added `scripts/test_stage8_windows.lua` covering float config defaults/validation, border styles, footer fallback behavior, highlight mapping, and panel float metadata passthrough.

## Why
- Stage 8 requires consistent, configurable floating-window border/title/footer styling and key-hint footers across the plugin UI.

## Key decisions/tradeoffs
- Footer rendering is feature-gated to `nvim-0.10+` for compatibility; older Neovim versions ignore footer fields without failing.
- Split layout behavior remains unchanged; float styling is applied when panels use float windows.
- Review panel remains fullscreen but now inherits configured border/title/footer styling for consistency.

## Testing
- `for t in $(ls scripts/test_stage*.lua | sort); do nvim --headless -u NONE -l "$t"; done`
