### PR TITLE
Issue #129: right now there is not bind for git stash

### DIFF
--- a/lua/gitflow/commands.lua
+++ b/lua/gitflow/commands.lua
@@ -2033,6 +2033,7 @@ function M.setup(cfg)
 	vim.keymap.set("n", "<Plug>(GitflowLog)", "<Cmd>Gitflow log<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowStash)", "<Cmd>Gitflow stash list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowStashPush)", "<Cmd>Gitflow stash push<CR>", { silent = true })
+	vim.keymap.set("n", "<Plug>(GitflowStashPop)", "<Cmd>Gitflow stash pop<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowIssue)", "<Cmd>Gitflow issue list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowPr)", "<Cmd>Gitflow pr list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowLabel)", "<Cmd>Gitflow label list<CR>", { silent = true })
@@ -2055,6 +2056,7 @@ function M.setup(cfg)
 		log = "<Plug>(GitflowLog)",
 		stash = "<Plug>(GitflowStash)",
 		stash_push = "<Plug>(GitflowStashPush)",
+		stash_pop = "<Plug>(GitflowStashPop)",
 		issue = "<Plug>(GitflowIssue)",
 		pr = "<Plug>(GitflowPr)",
 		label = "<Plug>(GitflowLabel)",

--- a/lua/gitflow/config.lua
+++ b/lua/gitflow/config.lua
@@ -74,6 +74,7 @@ function M.defaults()
 			log = "gl",
 			stash = "gS",
 			stash_push = "gZ",
+			stash_pop = "gX",
 			branch = "<leader>gb",
 			issue = "<leader>gI",
 			pr = "<leader>gR",

--- a/scripts/test_stage2.lua
+++ b/scripts/test_stage2.lua
@@ -171,6 +171,17 @@ assert_mapping(
 	"<Plug>(GitflowStashPush)",
 	"default stash push keymap should be registered"
 )
+assert_equals(cfg.keybindings.stash_pop, "gX", "default stash pop keybinding should exist")
+assert_mapping(
+	"<Plug>(GitflowStashPop)",
+	"<Cmd>Gitflow stash pop<CR>",
+	"stash pop plug keymap should be registered"
+)
+assert_mapping(
+	cfg.keybindings.stash_pop,
+	"<Plug>(GitflowStashPop)",
+	"default stash pop keymap should be registered"
+)
 
 local commands = require("gitflow.commands")
 local all_subcommands = commands.complete("")


### PR DESCRIPTION
Closes #129

## Summary

- Added a new global keybinding `gX` (`config.keybindings.stash_pop`) that maps to `<Plug>(GitflowStashPop)` and triggers `:Gitflow stash pop` directly from any buffer.
- This pairs with the existing `gZ` (stash push) and `gS` (stash panel) bindings, completing the stash quick-access story.
- The `:Gitflow stash pop` command already existed; this change only adds the missing global keybinding wiring.

### Files changed

- `lua/gitflow/config.lua` — added `stash_pop = "gX"` to default keybindings
- `lua/gitflow/commands.lua` — registered `<Plug>(GitflowStashPop)` mapping and added `stash_pop` to `key_to_plug` table
- `scripts/test_stage2.lua` — added smoke tests for stash pop keybinding registration

### Decisions

- Used `gX` per the issue suggestion, which fits the existing uppercase stash convention (`gS` = panel, `gZ` = push, `gX` = pop).
- Kept the change purely additive — no existing behavior modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)