### PR TITLE
Issue #146: Implement assign feature for issues / PR

### DIFF
--- a/lua/gitflow/commands.lua
+++ b/lua/gitflow/commands.lua
@@ -22,6 +22,7 @@ local conflict_panel = require("gitflow.panels.conflict")
 local palette_panel = require("gitflow.panels.palette")
 local git_conflict = require("gitflow.git.conflict")
 local label_completion = require("gitflow.completion.labels")
+local assignee_completion = require("gitflow.completion.assignees")
 
 ---@class GitflowSubcommand
 ---@field description string
@@ -1212,7 +1213,10 @@ local function register_builtin_subcommands(cfg)
 			if action == "edit" then
 				local number = first_positional_from(ctx.args, 3)
 				if not number then
-					return "Usage: :Gitflow issue edit <number> [title=...] [body=...] [add=...] [remove=...]"
+					return "Usage: :Gitflow issue edit <number>"
+						.. " [title=...] [body=...]"
+						.. " [add=...] [remove=...]"
+						.. " [add_assignees=...] [remove_assignees=...]"
 				end
 
 				local edit_opts = {}
@@ -1233,6 +1237,14 @@ local function register_builtin_subcommands(cfg)
 					local remove = token:match("^remove=(.+)$")
 					if remove then
 						edit_opts.remove_labels = parse_csv(remove)
+					end
+					local add_a = token:match("^add_assignees=(.+)$")
+					if add_a then
+						edit_opts.add_assignees = parse_csv(add_a)
+					end
+					local remove_a = token:match("^remove_assignees=(.+)$")
+					if remove_a then
+						edit_opts.remove_assignees = parse_csv(remove_a)
 					end
 				end
 
@@ -1504,7 +1516,10 @@ local function register_builtin_subcommands(cfg)
 			if action == "edit" then
 				local number = first_positional_from(ctx.args, 3)
 				if not number then
-					return "Usage: :Gitflow pr edit <number> [add=...] [remove=...] [reviewers=...]"
+					return "Usage: :Gitflow pr edit <number>"
+						.. " [add=...] [remove=...]"
+						.. " [add_assignees=...] [remove_assignees=...]"
+						.. " [reviewers=...]"
 				end
 
 				local edit_opts = {}
@@ -1517,6 +1532,14 @@ local function register_builtin_subcommands(cfg)
 					local remove = token:match("^remove=(.+)$")
 					if remove then
 						edit_opts.remove_labels = parse_csv(remove)
+					end
+					local add_a = token:match("^add_assignees=(.+)$")
+					if add_a then
+						edit_opts.add_assignees = parse_csv(add_a)
+					end
+					local remove_a = token:match("^remove_assignees=(.+)$")
+					if remove_a then
+						edit_opts.remove_assignees = parse_csv(remove_a)
 					end
 					local reviewers = token:match("^reviewers=(.+)$")
 					if reviewers then
@@ -1809,7 +1832,10 @@ local function complete_issue(subaction, arglead)
 	end
 
 	if subaction == "edit" then
-		return filter_candidates(arglead, { "title=", "body=", "add=", "remove=" })
+		return filter_candidates(arglead, {
+			"title=", "body=", "add=", "remove=",
+			"add_assignees=", "remove_assignees=",
+		})
 	end
 
 	return {}
@@ -1850,7 +1876,10 @@ local function complete_pr(subaction, arglead)
 	end
 
 	if subaction == "edit" then
-		return filter_candidates(arglead, { "add=", "remove=", "reviewers=" })
+		return filter_candidates(arglead, {
+			"add=", "remove=", "add_assignees=",
+			"remove_assignees=", "reviewers=",
+		})
 	end
 
 	if subaction == "review" or subaction == "submit-review" then
@@ -1982,6 +2011,16 @@ function M.complete(arglead, cmdline, _cursorpos)
 		if args[3] == "edit" and vim.startswith(arglead, "remove=") then
 			return label_completion.complete_token(arglead, "remove")
 		end
+		if args[3] == "edit" and vim.startswith(arglead, "add_assignees=") then
+			return assignee_completion.complete_token(arglead, "add_assignees")
+		end
+		if args[3] == "edit"
+			and vim.startswith(arglead, "remove_assignees=")
+		then
+			return assignee_completion.complete_token(
+				arglead, "remove_assignees"
+			)
+		end
 		return complete_issue(args[3], arglead)
 	end
 	if subcommand == "pr" then
@@ -1993,6 +2032,16 @@ function M.complete(arglead, cmdline, _cursorpos)
 		end
 		if args[3] == "edit" and vim.startswith(arglead, "remove=") then
 			return label_completion.complete_token(arglead, "remove")
+		end
+		if args[3] == "edit" and vim.startswith(arglead, "add_assignees=") then
+			return assignee_completion.complete_token(arglead, "add_assignees")
+		end
+		if args[3] == "edit"
+			and vim.startswith(arglead, "remove_assignees=")
+		then
+			return assignee_completion.complete_token(
+				arglead, "remove_assignees"
+			)
 		end
 		return complete_pr(args[3], arglead)
 	end

--- a/lua/gitflow/completion/assignees.lua
+++ b/lua/gitflow/completion/assignees.lua
@@ -1,0 +1,140 @@
+local M = {}
+
+local CACHE_TTL_SECONDS = 60
+
+---@type table{fetched_at: integer, assignees: string[]}
+local cache = {
+	fetched_at = 0,
+	assignees = {},
+}
+
+---@return string[]
+function M.fetch_repo_assignee_candidates()
+	local cmd = {
+		"gh", "api", "repos/{owner}/{repo}/assignees",
+		"--jq", ".[].login",
+		"--paginate",
+	}
+	local stdout = ""
+	if vim.system then
+		local result = vim.system(cmd, { text = true }):wait()
+		if (result.code or 1) ~= 0 then
+			return {}
+		end
+		stdout = result.stdout or ""
+	else
+		local output = vim.fn.system(cmd)
+		if vim.v.shell_error ~= 0 then
+			return {}
+		end
+		stdout = output or ""
+	end
+
+	local text = vim.trim(stdout)
+	if text == "" then
+		return {}
+	end
+
+	local names = {}
+	for _, line in ipairs(vim.split(text, "\n", { trimempty = true })) do
+		local name = vim.trim(line)
+		if name ~= "" then
+			names[#names + 1] = name
+		end
+	end
+	table.sort(names)
+	return names
+end
+
+---@return string[]
+function M.list_repo_assignee_candidates()
+	local now = os.time()
+	if now - cache.fetched_at <= CACHE_TTL_SECONDS then
+		return cache.assignees
+	end
+
+	local assignees = M.fetch_repo_assignee_candidates()
+	cache = {
+		fetched_at = now,
+		assignees = assignees,
+	}
+	return assignees
+end
+
+---@param prefix_csv string
+---@param strip_sign boolean
+---@return table<string, boolean>
+local function selected_assignees(prefix_csv, strip_sign)
+	local selected = {}
+	if prefix_csv == "" then
+		return selected
+	end
+
+	for _, token in ipairs(vim.split(prefix_csv, ",", { trimempty = true })) do
+		local trimmed = vim.trim(token)
+		if strip_sign then
+			trimmed = trimmed:gsub("^[-+]", "")
+		end
+		if trimmed ~= "" then
+			selected[trimmed] = true
+		end
+	end
+	return selected
+end
+
+---@param arglead string
+---@param key "add_assignees"|"remove_assignees"
+---@return string[]
+function M.complete_token(arglead, key)
+	local prefix = ("%s="):format(key)
+	if not vim.startswith(arglead, prefix) then
+		return {}
+	end
+
+	local raw = arglead:sub(#prefix + 1)
+	local prefix_csv = raw:match("^(.*,)") or ""
+	local current = raw:match("([^,]*)$") or raw
+	local selected = selected_assignees(prefix_csv, false)
+
+	local candidates = {}
+	for _, name in ipairs(M.list_repo_assignee_candidates()) do
+		if not selected[name]
+			and (current == "" or vim.startswith(name, current))
+		then
+			candidates[#candidates + 1] =
+				("%s%s%s"):format(prefix, prefix_csv, name)
+		end
+	end
+	return candidates
+end
+
+---@param arglead string|nil
+---@return string[]
+function M.complete_assignee_patch(arglead)
+	local raw = arglead or ""
+	local prefix_csv = raw:match("^(.*,)") or ""
+	local current = raw:match("([^,]*)$") or raw
+	local sign = ""
+	local current_name = current
+	if vim.startswith(current, "+") then
+		sign = "+"
+		current_name = current:sub(2)
+	elseif vim.startswith(current, "-") then
+		sign = "-"
+		current_name = current:sub(2)
+	end
+
+	local selected = selected_assignees(prefix_csv, true)
+	local candidates = {}
+	for _, name in ipairs(M.list_repo_assignee_candidates()) do
+		if not selected[name]
+			and (current_name == "" or vim.startswith(name, current_name))
+		then
+			candidates[#candidates + 1] =
+				("%s%s%s"):format(prefix_csv, sign, name)
+		end
+	end
+	return candidates
+end
+
+return M

--- a/lua/gitflow/gh/prs.lua
+++ b/lua/gitflow/gh/prs.lua
@@ -8,6 +8,7 @@ local PR_LIST_FIELDS = table.concat({
 	"state",
 	"isDraft",
 	"author",
+	"assignees",
 	"headRefName",
 	"baseRefName",
 	"updatedAt",
@@ -21,6 +22,7 @@ local PR_VIEW_FIELDS = table.concat({
 	"state",
 	"isDraft",
 	"author",
+	"assignees",
 	"headRefName",
 	"baseRefName",
 	"reviews",
@@ -485,6 +487,20 @@ function M.edit(number, input, opts, cb)
 	if remove_labels then
 		args[#args + 1] = "--remove-label"
 		args[#args + 1] = remove_labels
+		changed = true
+	end
+
+	local add_assignees = to_csv(options.add_assignees)
+	if add_assignees then
+		args[#args + 1] = "--add-assignee"
+		args[#args + 1] = add_assignees
+		changed = true
+	end
+
+	local remove_assignees = to_csv(options.remove_assignees)
+	if remove_assignees then
+		args[#args + 1] = "--remove-assignee"
+		args[#args + 1] = remove_assignees
 		changed = true
 	end
 

--- a/scripts/test_assign.lua
+++ b/scripts/test_assign.lua
@@ -1,0 +1,561 @@
+local script_path = debug.getinfo(1, "S").source:sub(2)
+local project_root = vim.fn.fnamemodify(script_path, ":p:h:h")
+vim.opt.runtimepath:append(project_root)
+
+local function assert_true(condition, message)
+	if not condition then
+		error(message, 2)
+	end
+end
+
+local function assert_equals(actual, expected, message)
+	if actual ~= expected then
+		error(
+			("%s (expected=%s, actual=%s)"):format(
+				message, vim.inspect(expected), vim.inspect(actual)
+			),
+			2
+		)
+	end
+end
+
+local function contains(list, value)
+	for _, item in ipairs(list) do
+		if item == value then
+			return true
+		end
+	end
+	return false
+end
+
+local function wait_until(predicate, message, timeout_ms)
+	local ok = vim.wait(timeout_ms or 5000, predicate, 20)
+	assert_true(ok, message)
+end
+
+local function find_line(lines, needle, start_line)
+	local from = start_line or 1
+	for i = from, #lines do
+		if lines[i]:find(needle, 1, true) then
+			return i
+		end
+	end
+	return nil
+end
+
+local function read_lines(path)
+	if vim.fn.filereadable(path) ~= 1 then
+		return {}
+	end
+	return vim.fn.readfile(path)
+end
+
+local function assert_keymaps(bufnr, required)
+	local keymaps = vim.api.nvim_buf_get_keymap(bufnr, "n")
+	local missing = {}
+	for _, lhs in ipairs(required) do
+		missing[lhs] = true
+	end
+	for _, map in ipairs(keymaps) do
+		if missing[map.lhs] ~= nil then
+			missing[map.lhs] = nil
+		end
+	end
+	for lhs, _ in pairs(missing) do
+		error(("missing keymap '%s'"):format(lhs), 2)
+	end
+end
+
+-- ── gh stub setup ──
+
+local stub_root = vim.fn.tempname()
+assert_equals(vim.fn.mkdir(stub_root, "p"), 1, "stub root")
+local stub_bin = stub_root .. "/bin"
+assert_equals(vim.fn.mkdir(stub_bin, "p"), 1, "stub bin")
+local gh_log = stub_root .. "/gh.log"
+
+local gh_script = [[#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$GITFLOW_GH_LOG"
+
+if [ "$#" -ge 1 ] && [ "$1" = "--version" ]; then
+  echo "gh version 2.55.0"
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  echo "Logged in to github.com as assign-test"
+  exit 0
+fi
+
+# Collaborators list for assignee completion
+if echo "$*" | grep -q "api repos/{owner}/{repo}/assignees"; then
+  printf 'alice\nbob\ncharlie\n'
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  sleep 0.10
+  cat <<'EOISSUE'
+[{"number":10,"title":"Assign test issue","state":"OPEN","labels":[{"name":"bug"}],"assignees":[{"login":"alice"}],"author":{"login":"octocat"},"updatedAt":"2026-02-10T00:00:00Z"}]
+EOISSUE
+  exit 0
+fi
+
+if [ "$#" -ge 3 ] && [ "$1" = "issue" ] && [ "$2" = "view" ] && [ "$3" = "10" ]; then
+  sleep 0.10
+  cat <<'EOVIEW'
+{"number":10,"title":"Assign test issue","body":"Body","state":"OPEN","labels":[{"name":"bug"}],"assignees":[{"login":"alice"}],"author":{"login":"octocat"},"comments":[]}
+EOVIEW
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "issue" ] && [ "$2" = "edit" ]; then
+  echo "issue edit ok"
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  sleep 0.10
+  cat <<'EOPR'
+[{"number":20,"title":"Assign test PR","state":"OPEN","isDraft":false,"author":{"login":"octocat"},"assignees":[{"login":"bob"}],"headRefName":"feat/assign","baseRefName":"main","updatedAt":"2026-02-10T00:00:00Z","mergedAt":null}]
+EOPR
+  exit 0
+fi
+
+if [ "$#" -ge 3 ] && [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = "20" ]; then
+  sleep 0.10
+  cat <<'EOPRVIEW'
+{"number":20,"title":"Assign test PR","body":"PR body","state":"OPEN","isDraft":false,"author":{"login":"octocat"},"assignees":[{"login":"bob"}],"headRefName":"feat/assign","baseRefName":"main","reviewRequests":[],"reviews":[],"comments":[],"files":[]}
+EOPRVIEW
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+  echo "pr edit ok"
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "label" ] && [ "$2" = "list" ]; then
+  echo '[{"name":"bug","color":"ff0000","description":"Bug"}]'
+  exit 0
+fi
+
+echo "unsupported gh args: $*" >&2
+exit 1
+]]
+
+local gh_path = stub_bin .. "/gh"
+vim.fn.writefile(vim.split(gh_script, "\n", { plain = true }), gh_path)
+vim.fn.setfperm(gh_path, "rwxr-xr-x")
+
+local original_path = vim.env.PATH
+local original_notify = vim.notify
+vim.env.PATH = stub_bin .. ":" .. (original_path or "")
+vim.env.GITFLOW_GH_LOG = gh_log
+
+local gitflow = require("gitflow")
+local cfg = gitflow.setup({
+	ui = {
+		default_layout = "split",
+		split = { orientation = "vertical", size = 44 },
+	},
+})
+
+local gh = require("gitflow.gh")
+assert_true(gh.state.checked, "gh should be checked")
+assert_true(gh.state.authenticated, "gh should be authenticated")
+
+local commands = require("gitflow.commands")
+local buffer = require("gitflow.ui.buffer")
+local issues_panel = require("gitflow.panels.issues")
+local pr_panel = require("gitflow.panels.prs")
+
+local notifications = {}
+vim.notify = function(message, level, _)
+	notifications[#notifications + 1] = {
+		message = tostring(message),
+		level = level,
+	}
+end
+
+local passed = 0
+local total = 0
+
+local function test(name, fn)
+	total = total + 1
+	local ok, err = pcall(fn)
+	if ok then
+		passed = passed + 1
+		print(("  PASS: %s"):format(name))
+	else
+		print(("  FAIL: %s — %s"):format(name, err))
+	end
+end
+
+-- ── 1. Completion module tests ──
+
+test("assignee completion fetches collaborators", function()
+	local completion = require("gitflow.completion.assignees")
+	local candidates = completion.list_repo_assignee_candidates()
+	assert_true(#candidates >= 3, "should fetch at least 3 collaborators")
+	assert_true(contains(candidates, "alice"), "should include alice")
+	assert_true(contains(candidates, "bob"), "should include bob")
+	assert_true(contains(candidates, "charlie"), "should include charlie")
+end)
+
+test("assignee patch completion: bare prefix", function()
+	local completion = require("gitflow.completion.assignees")
+	local candidates = completion.complete_assignee_patch("a")
+	assert_true(contains(candidates, "alice"), "should suggest alice")
+end)
+
+test("assignee patch completion: + prefix", function()
+	local completion = require("gitflow.completion.assignees")
+	local candidates = completion.complete_assignee_patch("+b")
+	assert_true(contains(candidates, "+bob"), "should suggest +bob")
+end)
+
+test("assignee patch completion: - prefix", function()
+	local completion = require("gitflow.completion.assignees")
+	local candidates = completion.complete_assignee_patch("-a")
+	assert_true(contains(candidates, "-alice"), "should suggest -alice")
+end)
+
+test("assignee patch completion: comma-separated", function()
+	local completion = require("gitflow.completion.assignees")
+	local candidates = completion.complete_assignee_patch("alice,b")
+	assert_true(
+		contains(candidates, "alice,bob"),
+		"should suggest alice,bob"
+	)
+	local has_alice_again = false
+	for _, c in ipairs(candidates) do
+		if c == "alice,alice" then
+			has_alice_again = true
+		end
+	end
+	assert_true(not has_alice_again, "should not re-suggest alice")
+end)
+
+test("assignee token completion: add_assignees=", function()
+	local completion = require("gitflow.completion.assignees")
+	local candidates = completion.complete_token(
+		"add_assignees=a", "add_assignees"
+	)
+	assert_true(
+		contains(candidates, "add_assignees=alice"),
+		"should suggest add_assignees=alice"
+	)
+end)
+
+test("assignee token completion: remove_assignees=", function()
+	local completion = require("gitflow.completion.assignees")
+	local candidates = completion.complete_token(
+		"remove_assignees=b", "remove_assignees"
+	)
+	assert_true(
+		contains(candidates, "remove_assignees=bob"),
+		"should suggest remove_assignees=bob"
+	)
+end)
+
+-- ── 2. Command-line edit completion tests ──
+
+test("issue edit completion includes add_assignees=", function()
+	local tokens = commands.complete("", "Gitflow issue edit 10 ", 0)
+	assert_true(
+		contains(tokens, "add_assignees="),
+		"should include add_assignees="
+	)
+	assert_true(
+		contains(tokens, "remove_assignees="),
+		"should include remove_assignees="
+	)
+end)
+
+test("pr edit completion includes add_assignees=", function()
+	local tokens = commands.complete("", "Gitflow pr edit 20 ", 0)
+	assert_true(
+		contains(tokens, "add_assignees="),
+		"should include add_assignees="
+	)
+	assert_true(
+		contains(tokens, "remove_assignees="),
+		"should include remove_assignees="
+	)
+end)
+
+test("issue edit add_assignees= tab-completion", function()
+	local candidates = commands.complete(
+		"add_assignees=a", "Gitflow issue edit 10 add_assignees=a", 0
+	)
+	assert_true(
+		contains(candidates, "add_assignees=alice"),
+		"should suggest alice"
+	)
+end)
+
+test("pr edit add_assignees= tab-completion", function()
+	local candidates = commands.complete(
+		"add_assignees=c", "Gitflow pr edit 20 add_assignees=c", 0
+	)
+	assert_true(
+		contains(candidates, "add_assignees=charlie"),
+		"should suggest charlie"
+	)
+end)
+
+-- ── 3. Issue panel assign keybind ──
+
+test("issue panel has A keybind", function()
+	commands.dispatch({ "issue", "list", "open" }, cfg)
+	wait_until(function()
+		local bufnr = buffer.get("issues")
+		if not bufnr then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+		return find_line(lines, "#10") ~= nil
+	end, "issue list should render")
+
+	local issue_buf = buffer.get("issues")
+	assert_true(issue_buf ~= nil, "issue panel should open")
+	assert_keymaps(issue_buf, { "A", "L" })
+end)
+
+test("issue list shows assignees", function()
+	local issue_buf = buffer.get("issues")
+	assert_true(issue_buf ~= nil, "issue buf exists")
+	local lines = vim.api.nvim_buf_get_lines(issue_buf, 0, -1, false)
+	assert_true(
+		find_line(lines, "assignees: alice") ~= nil,
+		"list should show assignees"
+	)
+end)
+
+test("issue view shows assignees", function()
+	commands.dispatch({ "issue", "view", "10" }, cfg)
+	wait_until(function()
+		local bufnr = buffer.get("issues")
+		if not bufnr then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+		return find_line(lines, "Assignees: alice") ~= nil
+	end, "issue view should show assignees")
+end)
+
+test("issue view footer includes A: assign", function()
+	local issue_buf = buffer.get("issues")
+	local lines = vim.api.nvim_buf_get_lines(issue_buf, 0, -1, false)
+	assert_true(
+		find_line(lines, "A: assign") ~= nil,
+		"view footer should include A: assign"
+	)
+end)
+
+-- ── 4. Issue panel assign prompt flow ──
+
+test("issue assign prompt calls gh issue edit with assignees", function()
+	local original_fn_input = vim.fn.input
+	local original_inputsave = vim.fn.inputsave
+	local original_inputrestore = vim.fn.inputrestore
+
+	vim.fn.inputsave = function() return 1 end
+	vim.fn.inputrestore = function() return 1 end
+
+	local assignee_prompt_seen = false
+	vim.fn.input = function(opts)
+		assignee_prompt_seen = true
+		local comp = opts.completion
+		assert_true(
+			type(comp) == "string",
+			"assign prompt should configure completion"
+		)
+		local fn_name = comp:match("^customlist,v:lua%.([%w_]+)$")
+		assert_true(fn_name ~= nil, "should use custom completion")
+		assert_true(
+			type(_G[fn_name]) == "function",
+			"completion function should exist"
+		)
+
+		local cands = _G[fn_name]("b", "", 0)
+		assert_true(
+			contains(cands, "bob"),
+			"assign completion should suggest bob"
+		)
+		return "+bob,-alice"
+	end
+
+	local gh_lines_before = #read_lines(gh_log)
+	issues_panel.edit_assignees_under_cursor()
+	wait_until(function()
+		local lines = read_lines(gh_log)
+		return find_line(
+			lines,
+			"issue edit 10 --add-assignee bob --remove-assignee alice",
+			gh_lines_before + 1
+		) ~= nil
+	end, "assign should call gh issue edit with --add-assignee/--remove-assignee")
+
+	assert_true(assignee_prompt_seen, "assign prompt should have been shown")
+
+	vim.fn.input = original_fn_input
+	vim.fn.inputsave = original_inputsave
+	vim.fn.inputrestore = original_inputrestore
+end)
+
+test("issue assign empty input warns", function()
+	local original_fn_input = vim.fn.input
+	local original_inputsave = vim.fn.inputsave
+	local original_inputrestore = vim.fn.inputrestore
+
+	vim.fn.inputsave = function() return 1 end
+	vim.fn.inputrestore = function() return 1 end
+	vim.fn.input = function(_) return "  " end
+
+	issues_panel.edit_assignees_under_cursor()
+	assert_true(
+		notifications[#notifications].message
+			== "No assignee edits provided",
+		"blank input should warn"
+	)
+
+	vim.fn.input = original_fn_input
+	vim.fn.inputsave = original_inputsave
+	vim.fn.inputrestore = original_inputrestore
+end)
+
+-- ── 5. PR panel assign keybind ──
+
+test("pr panel has A keybind", function()
+	commands.dispatch({ "pr", "list", "open" }, cfg)
+	wait_until(function()
+		local bufnr = buffer.get("prs")
+		if not bufnr then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+		return find_line(lines, "#20") ~= nil
+	end, "pr list should render")
+
+	local pr_buf = buffer.get("prs")
+	assert_true(pr_buf ~= nil, "pr panel should open")
+	assert_keymaps(pr_buf, { "A", "L" })
+end)
+
+test("pr list shows assignees", function()
+	local pr_buf = buffer.get("prs")
+	assert_true(pr_buf ~= nil, "pr buf exists")
+	local lines = vim.api.nvim_buf_get_lines(pr_buf, 0, -1, false)
+	assert_true(
+		find_line(lines, "assignees: bob") ~= nil,
+		"pr list should show assignees"
+	)
+end)
+
+test("pr view shows assignees", function()
+	commands.dispatch({ "pr", "view", "20" }, cfg)
+	wait_until(function()
+		local bufnr = buffer.get("prs")
+		if not bufnr then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+		return find_line(lines, "Assignees: bob") ~= nil
+	end, "pr view should show assignees")
+end)
+
+test("pr view footer includes A: assign", function()
+	local pr_buf = buffer.get("prs")
+	local lines = vim.api.nvim_buf_get_lines(pr_buf, 0, -1, false)
+	assert_true(
+		find_line(lines, "A: assign") ~= nil,
+		"pr view footer should include A: assign"
+	)
+end)
+
+-- ── 6. PR panel assign prompt flow ──
+
+test("pr assign prompt calls gh pr edit with assignees", function()
+	local original_fn_input = vim.fn.input
+	local original_inputsave = vim.fn.inputsave
+	local original_inputrestore = vim.fn.inputrestore
+
+	vim.fn.inputsave = function() return 1 end
+	vim.fn.inputrestore = function() return 1 end
+	vim.fn.input = function(_) return "charlie" end
+
+	local gh_lines_before = #read_lines(gh_log)
+	pr_panel.edit_assignees_under_cursor()
+	wait_until(function()
+		local lines = read_lines(gh_log)
+		return find_line(
+			lines,
+			"pr edit 20 --add-assignee charlie",
+			gh_lines_before + 1
+		) ~= nil
+	end, "pr assign should call gh pr edit with --add-assignee")
+
+	vim.fn.input = original_fn_input
+	vim.fn.inputsave = original_inputsave
+	vim.fn.inputrestore = original_inputrestore
+end)
+
+-- ── 7. CLI assign dispatch ──
+
+test("issue edit with add_assignees= dispatches correctly", function()
+	local gh_lines_before = #read_lines(gh_log)
+	commands.dispatch(
+		{ "issue", "edit", "10", "add_assignees=bob,charlie" }, cfg
+	)
+	wait_until(function()
+		local lines = read_lines(gh_log)
+		return find_line(
+			lines,
+			"issue edit 10 --add-assignee bob,charlie",
+			gh_lines_before + 1
+		) ~= nil
+	end, "CLI issue edit add_assignees= should pass to gh")
+end)
+
+test("pr edit with add_assignees= dispatches correctly", function()
+	local gh_lines_before = #read_lines(gh_log)
+	commands.dispatch(
+		{ "pr", "edit", "20", "add_assignees=alice" }, cfg
+	)
+	wait_until(function()
+		local lines = read_lines(gh_log)
+		return find_line(
+			lines,
+			"pr edit 20 --add-assignee alice",
+			gh_lines_before + 1
+		) ~= nil
+	end, "CLI pr edit add_assignees= should pass to gh")
+end)
+
+test("issue edit with remove_assignees= dispatches correctly", function()
+	local gh_lines_before = #read_lines(gh_log)
+	commands.dispatch(
+		{ "issue", "edit", "10", "remove_assignees=alice" }, cfg
+	)
+	wait_until(function()
+		local lines = read_lines(gh_log)
+		return find_line(
+			lines,
+			"issue edit 10 --remove-assignee alice",
+			gh_lines_before + 1
+		) ~= nil
+	end, "CLI issue edit remove_assignees= should pass to gh")
+end)
+
+-- ── Cleanup ──
+
+vim.notify = original_notify
+vim.env.PATH = original_path
+
+print(("Assign smoke tests: %d/%d passed"):format(passed, total))
+if passed < total then
+	vim.cmd("cquit! 1")
+end


### PR DESCRIPTION
Closes #146

## Summary

Adds an assign/unassign feature to both issue and PR panels with autocomplete
from repository collaborators.

### What changed

- **New module** `lua/gitflow/completion/assignees.lua` — fetches repo
  collaborators via `gh api repos/{owner}/{repo}/assignees`, caches for 60s,
  provides patch-format completion (`+user,-user,user`) and token completion
  (`add_assignees=user1,user2`).
- **Issue panel** (`lua/gitflow/panels/issues.lua`) — `A` keybind triggers
  assignee editing with autocomplete; list and view modes now display assignees.
- **PR panel** (`lua/gitflow/panels/prs.lua`) — same `A` keybind and flow;
  list and view modes display assignees.
- **`gh/prs.lua`** — `PR_LIST_FIELDS` and `PR_VIEW_FIELDS` now include
  `assignees`; `M.edit()` supports `add_assignees`/`remove_assignees`.
- **`commands.lua`** — `:Gitflow issue/pr edit` accepts `add_assignees=` and
  `remove_assignees=` tokens with tab completion for collaborator names.
- Footer hints updated in both panels to include `A: assign`.

### Testing

- New smoke test: `scripts/test_assign.lua` (25 tests) covering completion
  module, CLI edit tokens, panel keybinds, rendering, prompt flow, and gh CLI
  invocation.
- No regressions in previously passing tests (stages 1, 6, 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)