### PR TITLE
Issue #161: Git stash menu has redundant displayed keybinds at the top of the file

### DIFF
--- a/lua/gitflow/panels/conflict.lua
+++ b/lua/gitflow/panels/conflict.lua
@@ -177,10 +177,6 @@ local function render(files, operation)
 		end
 	end
 
-	lines[#lines + 1] = ""
-	lines[#lines + 1] = "<CR>: open 3-way view  r/R: refresh"
-	lines[#lines + 1] = "C: continue operation  A: abort operation  q: quit"
-
 	ui.buffer.update("conflict", lines)
 	M.state.files = files
 	M.state.line_entries = line_entries
@@ -195,8 +191,6 @@ local function render(files, operation)
 	vim.api.nvim_buf_add_highlight(bufnr, CONFLICT_HIGHLIGHT_NS, "GitflowTitle", 0, 0, -1)
 	vim.api.nvim_buf_add_highlight(bufnr, CONFLICT_HIGHLIGHT_NS, "GitflowHeader", 2, 0, -1)
 	vim.api.nvim_buf_add_highlight(bufnr, CONFLICT_HIGHLIGHT_NS, "GitflowHeader", 3, 0, -1)
-	vim.api.nvim_buf_add_highlight(bufnr, CONFLICT_HIGHLIGHT_NS, "GitflowFooter", #lines - 2, 0, -1)
-	vim.api.nvim_buf_add_highlight(bufnr, CONFLICT_HIGHLIGHT_NS, "GitflowFooter", #lines - 1, 0, -1)
 
 	for line_no, _ in pairs(line_entries) do
 		vim.api.nvim_buf_add_highlight(

--- a/lua/gitflow/panels/issues.lua
+++ b/lua/gitflow/panels/issues.lua
@@ -258,10 +258,6 @@ local function render_list(issues)
 		end
 	end
 
-	lines[#lines + 1] = ""
-	lines[#lines + 1] = "<CR>: view  c: create  C: comment  x: close"
-		.. "  L: labels  A: assign  r: refresh  q: quit"
-
 	ui.buffer.update("issues", lines)
 	M.state.line_entries = line_entries
 	M.state.mode = "list"
@@ -274,7 +270,6 @@ local function render_list(issues)
 
 	vim.api.nvim_buf_clear_namespace(bufnr, ISSUES_HIGHLIGHT_NS, 0, -1)
 	vim.api.nvim_buf_add_highlight(bufnr, ISSUES_HIGHLIGHT_NS, "GitflowTitle", 0, 0, -1)
-	vim.api.nvim_buf_add_highlight(bufnr, ISSUES_HIGHLIGHT_NS, "GitflowFooter", #lines - 1, 0, -1)
 
 	for line_no, issue in pairs(line_entries) do
 		local group = issue_highlight_group(issue_state(issue))
@@ -329,9 +324,6 @@ local function render_view(issue)
 		end
 	end
 
-	lines[#lines + 1] =
-		"b: back to list  C: comment  x: close  L: labels  A: assign  r: refresh"
-
 	ui.buffer.update("issues", lines)
 	M.state.line_entries = {}
 	M.state.mode = "view"
@@ -344,7 +336,6 @@ local function render_view(issue)
 
 	vim.api.nvim_buf_clear_namespace(bufnr, ISSUES_HIGHLIGHT_NS, 0, -1)
 	vim.api.nvim_buf_add_highlight(bufnr, ISSUES_HIGHLIGHT_NS, "GitflowTitle", 0, 0, -1)
-	vim.api.nvim_buf_add_highlight(bufnr, ISSUES_HIGHLIGHT_NS, "GitflowFooter", #lines - 1, 0, -1)
 	vim.api.nvim_buf_add_highlight(
 		bufnr,
 		ISSUES_HIGHLIGHT_NS,

--- a/lua/gitflow/panels/prs.lua
+++ b/lua/gitflow/panels/prs.lua
@@ -259,10 +259,6 @@ local function render_list(prs)
 		end
 	end
 
-	lines[#lines + 1] = ""
-	lines[#lines + 1] = "<CR>: view  c: create  C: comment  L: labels"
-		.. "  A: assign  m: merge  o: checkout  v: review  r: refresh  q: quit"
-
 	ui.buffer.update("prs", lines)
 	M.state.line_entries = line_entries
 	M.state.mode = "list"
@@ -275,7 +271,6 @@ local function render_list(prs)
 
 	vim.api.nvim_buf_clear_namespace(bufnr, PRS_HIGHLIGHT_NS, 0, -1)
 	vim.api.nvim_buf_add_highlight(bufnr, PRS_HIGHLIGHT_NS, "GitflowTitle", 0, 0, -1)
-	vim.api.nvim_buf_add_highlight(bufnr, PRS_HIGHLIGHT_NS, "GitflowFooter", #lines - 1, 0, -1)
 
 	for line_no, pr in pairs(line_entries) do
 		local group = pr_highlight_group(pr_state(pr))
@@ -313,10 +308,6 @@ local function render_view(pr)
 	lines[#lines + 1] = ("Reviews: %d"):format(type(pr.reviews) == "table" and #pr.reviews or 0)
 	lines[#lines + 1] = ("Comments: %d"):format(type(pr.comments) == "table" and #pr.comments or 0)
 	lines[#lines + 1] = ("Changed files: %d"):format(type(pr.files) == "table" and #pr.files or 0)
-	lines[#lines + 1] = ""
-	lines[#lines + 1] = "b: back to list  C: comment  L: labels  A: assign"
-		.. "  m: merge  o: checkout  v: review  r: refresh"
-
 	ui.buffer.update("prs", lines)
 	M.state.line_entries = {}
 	M.state.mode = "view"
@@ -329,7 +320,6 @@ local function render_view(pr)
 
 	vim.api.nvim_buf_clear_namespace(bufnr, PRS_HIGHLIGHT_NS, 0, -1)
 	vim.api.nvim_buf_add_highlight(bufnr, PRS_HIGHLIGHT_NS, "GitflowTitle", 0, 0, -1)
-	vim.api.nvim_buf_add_highlight(bufnr, PRS_HIGHLIGHT_NS, "GitflowFooter", #lines - 1, 0, -1)
 	vim.api.nvim_buf_add_highlight(
 		bufnr,
 		PRS_HIGHLIGHT_NS,

--- a/lua/gitflow/panels/review.lua
+++ b/lua/gitflow/panels/review.lua
@@ -469,16 +469,6 @@ local function render_review(
 				:format(#M.state.pending_comments)
 	end
 	lines[#lines + 1] = ""
-	lines[#lines + 1] = "Navigation: ]f/[f file  ]c/[c hunk"
-	lines[#lines + 1] =
-		"Actions: a approve  x request changes"
-	lines[#lines + 1] =
-		"         c inline note  R reply"
-	lines[#lines + 1] =
-		"         S submit review  <leader>t toggle thread"
-	lines[#lines + 1] =
-		"         r refresh  <leader>b back  q quit"
-	lines[#lines + 1] = ""
 
 	-- B1: render existing review comment threads above the diff
 	local thread_line_map = {}
@@ -542,19 +532,7 @@ local function render_review(
 		end
 
 		for line_no, line in ipairs(lines) do
-			if vim.startswith(line, "Navigation:")
-				or vim.startswith(line, "Actions:")
-				or vim.startswith(line, "         ")
-			then
-				vim.api.nvim_buf_add_highlight(
-					M.state.bufnr,
-					REVIEW_HIGHLIGHT_NS,
-					"GitflowFooter",
-					line_no - 1,
-					0,
-					-1
-				)
-			elseif vim.startswith(line, "Review Comments") then
+			if vim.startswith(line, "Review Comments") then
 				vim.api.nvim_buf_add_highlight(
 					M.state.bufnr,
 					REVIEW_HIGHLIGHT_NS,

--- a/lua/gitflow/panels/stash.lua
+++ b/lua/gitflow/panels/stash.lua
@@ -100,7 +100,6 @@ end
 local function render(entries, current_branch)
 	local lines = {
 		"Gitflow Stash",
-		"P=Pop  D=Drop  S=Stash  r=Refresh  q=Close",
 		"",
 	}
 	local line_entries = {}


### PR DESCRIPTION
Closes #161

## Summary

Multiple panel menus displayed keybind hints as inline buffer text that
duplicates the keybinds already shown in the floating window border footer.
The inline text was the old/deprecated approach and has been removed.

### What changed
- **stash.lua**: Removed `P=Pop  D=Drop  S=Stash  r=Refresh  q=Close` header
  line from `render()`
- **issues.lua**: Removed inline keybind lines from both `render_list()` and
  `render_view()`, plus their associated `GitflowFooter` highlight calls
- **prs.lua**: Removed inline keybind lines from both `render_list()` and
  `render_view()`, plus their associated `GitflowFooter` highlight calls
- **review.lua**: Removed the 5-line Navigation/Actions keybind block from
  `render_review()` and its `GitflowFooter` highlight matching logic
- **conflict.lua**: Removed 2 inline keybind lines from `render()` and their
  associated `GitflowFooter` highlight calls

### Why
The border footer already shows all keybind hints. The inline text was
redundant visual noise from the old rendering approach.

### Key decisions
- Pure cosmetic removal — no keybind behavior or border footer display is
  affected
- Cleaned up orphaned `GitflowFooter` highlight references that targeted the
  removed lines

## Test plan
- [x] Stage 1 smoke tests pass
- [x] Stage 6 conflict tests pass
- [x] Stage 8 highlights tests pass
- [x] Stage 8 windows tests pass
- [x] Stage 10 palette tests pass
- [ ] Open stash panel and verify no inline keybinds in buffer, border footer
  still shows hints
- [ ] Open issues list/view and verify same
- [ ] Open PRs list/view and verify same
- [ ] Open review panel and verify same
- [ ] Open conflict panel and verify same

🤖 Generated with [Claude Code](https://claude.com/claude-code)