### PR TITLE
Issue #139: Implement git reset menu

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -27,6 +27,7 @@ Normal-mode mappings available in any buffer. Configured via
 | `<leader>gI` | Open issue list | `issue` |
 | `<leader>gR` | Open PR list | `pr` |
 | `<leader>gL` | Open label list | `label` |
+| `gR` | Open reset panel | `reset` |
 | `<leader>gm` | Open conflict panel | `conflict` |
 | `<leader>gp` | Open command palette | `palette` |
 
@@ -79,6 +80,19 @@ Buffer-local bindings active in the log panel (`:Gitflow log`).
 | Key | Action |
 | --- | --- |
 | `<CR>` | Open diff for commit under cursor |
+| `r` | Refresh |
+| `q` | Close |
+
+## Reset Panel
+
+Buffer-local bindings active in the reset panel (`:Gitflow reset`).
+
+| Key | Action |
+| --- | --- |
+| `<CR>` | Select commit under cursor (prompts soft/hard) |
+| `1`-`9` | Select commit by position (prompts soft/hard) |
+| `S` | Soft reset to commit under cursor |
+| `H` | Hard reset to commit under cursor |
 | `r` | Refresh |
 | `q` | Close |
 

--- a/lua/gitflow/commands.lua
+++ b/lua/gitflow/commands.lua
@@ -20,6 +20,7 @@ local label_panel = require("gitflow.panels.labels")
 local review_panel = require("gitflow.panels.review")
 local conflict_panel = require("gitflow.panels.conflict")
 local palette_panel = require("gitflow.panels.palette")
+local reset_panel = require("gitflow.panels.reset")
 local git_conflict = require("gitflow.git.conflict")
 local label_completion = require("gitflow.completion.labels")
 local assignee_completion = require("gitflow.completion.assignees")
@@ -969,6 +970,7 @@ local function register_builtin_subcommands(cfg)
 			label_panel.close()
 			review_panel.close()
 			conflict_panel.close()
+			reset_panel.close()
 			palette_panel.close()
 			return "Gitflow panels closed"
 		end,
@@ -1089,6 +1091,14 @@ local function register_builtin_subcommands(cfg)
 				end,
 			})
 			return "Log view opened"
+		end,
+	}
+
+	M.subcommands.reset = {
+		description = "Open git reset panel",
+		run = function()
+			reset_panel.open(cfg)
+			return "Reset panel opened"
 		end,
 	}
 
@@ -2133,6 +2143,7 @@ function M.setup(cfg)
 	vim.keymap.set("n", "<Plug>(GitflowPr)", "<Cmd>Gitflow pr list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowLabel)", "<Cmd>Gitflow label list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowPalette)", "<Cmd>Gitflow palette<CR>", { silent = true })
+	vim.keymap.set("n", "<Plug>(GitflowReset)", "<Cmd>Gitflow reset<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowConflict)", "<Cmd>Gitflow conflicts<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowConflicts)", "<Cmd>Gitflow conflicts<CR>", { silent = true })
 
@@ -2154,6 +2165,7 @@ function M.setup(cfg)
 		issue = "<Plug>(GitflowIssue)",
 		pr = "<Plug>(GitflowPr)",
 		label = "<Plug>(GitflowLabel)",
+		reset = "<Plug>(GitflowReset)",
 		palette = "<Plug>(GitflowPalette)",
 		conflict = "<Plug>(GitflowConflicts)",
 	}

--- a/lua/gitflow/config.lua
+++ b/lua/gitflow/config.lua
@@ -83,6 +83,7 @@ function M.defaults()
 			branch = "<leader>gb",
 			issue = "<leader>gi",
 			pr = "<leader>gr",
+			reset = "gR",
 			conflict = "<leader>gm",
 			palette = "<leader>go",
 		},

--- a/lua/gitflow/git/reset.lua
+++ b/lua/gitflow/git/reset.lua
@@ -1,0 +1,91 @@
+local git = require("gitflow.git")
+local git_log = require("gitflow.git.log")
+
+---@class GitflowResetEntry
+---@field sha string
+---@field short_sha string
+---@field summary string
+
+local M = {}
+
+---@param result GitflowGitResult
+---@param action string
+---@return string
+local function error_from_result(result, action)
+	local output = git.output(result)
+	if output == "" then
+		return ("git %s failed"):format(action)
+	end
+	return ("git %s failed: %s"):format(action, output)
+end
+
+---List recent commits on the current branch.
+---Delegates to git log with a tab-separated full-SHA + summary format.
+---@param opts table|nil  { count?: integer }
+---@param cb fun(err: string|nil, entries: GitflowResetEntry[]|nil)
+function M.list_commits(opts, cb)
+	local options = opts or {}
+	local count = tonumber(options.count) or 50
+	git_log.list({ count = count }, function(err, entries)
+		if err then
+			cb(err, nil)
+			return
+		end
+		cb(nil, entries)
+	end)
+end
+
+---Find the merge-base commit between HEAD and the default branch.
+---Tries main, then master, then origin/HEAD.
+---@param opts table|nil
+---@param cb fun(err: string|nil, sha: string|nil)
+function M.find_merge_base(opts, cb)
+	local candidates = { "main", "master", "origin/HEAD" }
+
+	local function try_next(index)
+		if index > #candidates then
+			cb(nil, nil)
+			return
+		end
+
+		local ref = candidates[index]
+		git.git({ "merge-base", "HEAD", ref }, opts or {}, function(result)
+			if result.code == 0 then
+				local sha = vim.trim(result.stdout or "")
+				if sha ~= "" then
+					cb(nil, sha)
+					return
+				end
+			end
+			try_next(index + 1)
+		end)
+	end
+
+	try_next(1)
+end
+
+---Execute git reset to a given commit.
+---@param sha string  target commit SHA
+---@param mode "soft"|"hard"  reset mode
+---@param cb fun(err: string|nil, result: GitflowGitResult)
+function M.reset(sha, mode, cb)
+	if not sha or sha == "" then
+		error("gitflow reset error: reset(sha, mode, cb) requires a SHA", 2)
+	end
+	if mode ~= "soft" and mode ~= "hard" then
+		error(
+			"gitflow reset error: mode must be 'soft' or 'hard'", 2
+		)
+	end
+
+	local flag = ("--" .. mode)
+	git.git({ "reset", flag, sha }, {}, function(result)
+		if result.code ~= 0 then
+			cb(error_from_result(result, "reset"), result)
+			return
+		end
+		cb(nil, result)
+	end)
+end
+
+return M

--- a/lua/gitflow/highlights.lua
+++ b/lua/gitflow/highlights.lua
@@ -50,6 +50,8 @@ M.DEFAULT_GROUPS = {
 	},
 	GitflowPaletteEntryIcon = { fg = "#56B6C2" },
 	GitflowPaletteBackdrop = { bg = "#000000" },
+	-- Reset
+	GitflowResetMergeBase = { link = "WarningMsg" },
 	-- Form
 	GitflowFormLabel = { fg = "#56B6C2", bold = true },
 	GitflowFormActiveField = { link = "CursorLine" },

--- a/lua/gitflow/icons.lua
+++ b/lua/gitflow/icons.lua
@@ -100,6 +100,7 @@ local registry = {
 		issue = { nerd = NF.issue_open, ascii = "#" },
 		pr = { nerd = NF.pr_open, ascii = "!" },
 		review = { nerd = NF.review_commented, ascii = "R" },
+		reset = { nerd = NF.commit, ascii = "R" },
 		palette = { nerd = NF.palette_ui, ascii = ">" },
 		help = { nerd = NF.palette_ui, ascii = "?" },
 		open = { nerd = NF.palette_ui, ascii = ">" },

--- a/lua/gitflow/panels/reset.lua
+++ b/lua/gitflow/panels/reset.lua
@@ -1,0 +1,350 @@
+local ui = require("gitflow.ui")
+local utils = require("gitflow.utils")
+local git = require("gitflow.git")
+local git_reset = require("gitflow.git.reset")
+local git_branch = require("gitflow.git.branch")
+local icons = require("gitflow.icons")
+local ui_render = require("gitflow.ui.render")
+local status_panel = require("gitflow.panels.status")
+
+---@class GitflowResetPanelState
+---@field bufnr integer|nil
+---@field winid integer|nil
+---@field line_entries table<integer, GitflowResetEntry>
+---@field merge_base_sha string|nil
+---@field cfg GitflowConfig|nil
+
+local M = {}
+local RESET_FLOAT_TITLE = "Gitflow Reset"
+local RESET_FLOAT_FOOTER =
+	"<CR> select  1-9 by position  S soft reset  H hard reset  r refresh  q close"
+local RESET_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_reset_hl")
+
+---@type GitflowResetPanelState
+M.state = {
+	bufnr = nil,
+	winid = nil,
+	line_entries = {},
+	merge_base_sha = nil,
+	cfg = nil,
+}
+
+local function refresh_status_panel_if_open()
+	if status_panel.is_open() then
+		status_panel.refresh()
+	end
+end
+
+local function emit_post_operation()
+	vim.api.nvim_exec_autocmds("User", { pattern = "GitflowPostOperation" })
+end
+
+---@param cfg GitflowConfig
+local function ensure_window(cfg)
+	local bufnr = M.state.bufnr
+		and vim.api.nvim_buf_is_valid(M.state.bufnr)
+		and M.state.bufnr or nil
+	if not bufnr then
+		bufnr = ui.buffer.create("reset", {
+			filetype = "gitflowreset",
+			lines = { "Loading commits..." },
+		})
+		M.state.bufnr = bufnr
+	end
+
+	vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+
+	if M.state.winid and vim.api.nvim_win_is_valid(M.state.winid) then
+		vim.api.nvim_win_set_buf(M.state.winid, bufnr)
+		return
+	end
+
+	if cfg.ui.default_layout == "float" then
+		M.state.winid = ui.window.open_float({
+			name = "reset",
+			bufnr = bufnr,
+			width = cfg.ui.float.width,
+			height = cfg.ui.float.height,
+			border = cfg.ui.float.border,
+			title = RESET_FLOAT_TITLE,
+			title_pos = cfg.ui.float.title_pos,
+			footer = cfg.ui.float.footer and RESET_FLOAT_FOOTER or nil,
+			footer_pos = cfg.ui.float.footer_pos,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	else
+		M.state.winid = ui.window.open_split({
+			name = "reset",
+			bufnr = bufnr,
+			orientation = cfg.ui.split.orientation,
+			size = cfg.ui.split.size,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	end
+
+	vim.keymap.set("n", "<CR>", function()
+		M.select_under_cursor()
+	end, { buffer = bufnr, silent = true })
+
+	for i = 1, 9 do
+		vim.keymap.set("n", tostring(i), function()
+			M.select_by_position(i)
+		end, { buffer = bufnr, silent = true, nowait = true })
+	end
+
+	vim.keymap.set("n", "S", function()
+		M.reset_under_cursor("soft")
+	end, { buffer = bufnr, silent = true, nowait = true })
+
+	vim.keymap.set("n", "H", function()
+		M.reset_under_cursor("hard")
+	end, { buffer = bufnr, silent = true, nowait = true })
+
+	vim.keymap.set("n", "r", function()
+		M.refresh()
+	end, { buffer = bufnr, silent = true, nowait = true })
+
+	vim.keymap.set("n", "q", function()
+		M.close()
+	end, { buffer = bufnr, silent = true, nowait = true })
+end
+
+---@param entries GitflowResetEntry[]
+---@param merge_base_sha string|nil
+---@param current_branch string
+local function render(entries, merge_base_sha, current_branch)
+	local render_opts = {
+		bufnr = M.state.bufnr,
+		winid = M.state.winid,
+	}
+	local lines = ui_render.panel_header("Gitflow Reset", render_opts)
+	local line_entries = {}
+	local entry_highlights = {}
+
+	if #entries == 0 then
+		lines[#lines + 1] = ui_render.empty("no commits found")
+	else
+		for idx, entry in ipairs(entries) do
+			local commit_icon = icons.get("git_state", "commit")
+			local position_marker = ""
+			if idx <= 9 then
+				position_marker = ("[%d] "):format(idx)
+			end
+			lines[#lines + 1] = ui_render.entry(
+				("%s%s %s %s"):format(
+					position_marker,
+					commit_icon,
+					entry.short_sha,
+					entry.summary
+				)
+			)
+			line_entries[#lines] = entry
+
+			if merge_base_sha
+				and entry.sha:sub(1, #merge_base_sha) == merge_base_sha
+			then
+				entry_highlights[#lines] = "GitflowResetMergeBase"
+			elseif merge_base_sha
+				and merge_base_sha:sub(1, #entry.sha) == entry.sha
+			then
+				entry_highlights[#lines] = "GitflowResetMergeBase"
+			end
+		end
+	end
+
+	local footer_lines = ui_render.panel_footer(
+		current_branch, nil, render_opts
+	)
+	for _, line in ipairs(footer_lines) do
+		lines[#lines + 1] = line
+	end
+
+	ui.buffer.update("reset", lines)
+	M.state.line_entries = line_entries
+	M.state.merge_base_sha = merge_base_sha
+
+	local bufnr = M.state.bufnr
+	if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+		return
+	end
+
+	ui_render.apply_panel_highlights(bufnr, RESET_HIGHLIGHT_NS, lines, {
+		footer_line = #lines,
+		entry_highlights = entry_highlights,
+	})
+end
+
+---@return GitflowResetEntry|nil
+local function entry_under_cursor()
+	if not M.state.bufnr
+		or vim.api.nvim_get_current_buf() ~= M.state.bufnr
+	then
+		return nil
+	end
+	local line = vim.api.nvim_win_get_cursor(0)[1]
+	return M.state.line_entries[line]
+end
+
+---Find the Nth entry (1-indexed) from the line_entries map.
+---@param position integer
+---@return GitflowResetEntry|nil
+local function entry_by_position(position)
+	local sorted_lines = {}
+	for line_no, _ in pairs(M.state.line_entries) do
+		sorted_lines[#sorted_lines + 1] = line_no
+	end
+	table.sort(sorted_lines)
+
+	if position < 1 or position > #sorted_lines then
+		return nil
+	end
+	return M.state.line_entries[sorted_lines[position]]
+end
+
+---Prompt user for soft/hard and execute reset.
+---@param entry GitflowResetEntry
+---@param mode "soft"|"hard"|nil  if provided, skip the confirm prompt
+local function execute_reset(entry, mode)
+	if mode then
+		local label = mode == "hard" and "HARD" or "soft"
+		local confirmed = ui.input.confirm(
+			("Reset %s to %s %s?\n\nThis will %s."):format(
+				label,
+				entry.short_sha,
+				entry.summary,
+				mode == "hard"
+					and "DISCARD all changes after this commit"
+					or "keep changes as uncommitted"
+			),
+			{
+				choices = { "&Reset", "&Cancel" },
+				default_choice = mode == "hard" and 2 or 1,
+			}
+		)
+		if not confirmed then
+			return
+		end
+
+		git_reset.reset(entry.sha, mode, function(err, result)
+			if err then
+				utils.notify(err, vim.log.levels.ERROR)
+				return
+			end
+			local output = git.output(result)
+			if output == "" then
+				output = ("Reset %s to %s"):format(mode, entry.short_sha)
+			end
+			utils.notify(output, vim.log.levels.INFO)
+			M.close()
+			refresh_status_panel_if_open()
+			emit_post_operation()
+		end)
+		return
+	end
+
+	local _, choice_idx = ui.input.confirm(
+		("Reset to %s %s?"):format(entry.short_sha, entry.summary),
+		{
+			choices = { "&Soft", "&Hard", "&Cancel" },
+			default_choice = 1,
+		}
+	)
+
+	if choice_idx == 1 then
+		execute_reset(entry, "soft")
+	elseif choice_idx == 2 then
+		execute_reset(entry, "hard")
+	end
+end
+
+---@param cfg GitflowConfig
+function M.open(cfg)
+	M.state.cfg = cfg
+	ensure_window(cfg)
+	M.refresh()
+end
+
+function M.refresh()
+	local cfg = M.state.cfg
+	if not cfg then
+		return
+	end
+
+	git_branch.current({}, function(_, branch)
+		git_reset.list_commits({
+			count = cfg.git.log.count,
+		}, function(log_err, entries)
+			if log_err then
+				utils.notify(log_err, vim.log.levels.ERROR)
+				return
+			end
+
+			git_reset.find_merge_base({}, function(_, merge_base)
+				render(entries or {}, merge_base, branch or "(unknown)")
+			end)
+		end)
+	end)
+end
+
+function M.select_under_cursor()
+	local entry = entry_under_cursor()
+	if not entry then
+		utils.notify("No commit selected", vim.log.levels.WARN)
+		return
+	end
+	execute_reset(entry)
+end
+
+---@param position integer
+function M.select_by_position(position)
+	local entry = entry_by_position(position)
+	if not entry then
+		utils.notify(
+			("No commit at position %d"):format(position),
+			vim.log.levels.WARN
+		)
+		return
+	end
+	execute_reset(entry)
+end
+
+---@param mode "soft"|"hard"
+function M.reset_under_cursor(mode)
+	local entry = entry_under_cursor()
+	if not entry then
+		utils.notify("No commit selected", vim.log.levels.WARN)
+		return
+	end
+	execute_reset(entry, mode)
+end
+
+function M.close()
+	if M.state.winid then
+		ui.window.close(M.state.winid)
+	else
+		ui.window.close("reset")
+	end
+
+	if M.state.bufnr then
+		ui.buffer.teardown(M.state.bufnr)
+	else
+		ui.buffer.teardown("reset")
+	end
+
+	M.state.bufnr = nil
+	M.state.winid = nil
+	M.state.line_entries = {}
+	M.state.merge_base_sha = nil
+end
+
+---@return boolean
+function M.is_open()
+	return M.state.bufnr ~= nil
+		and vim.api.nvim_buf_is_valid(M.state.bufnr)
+end
+
+return M

--- a/scripts/test_reset.lua
+++ b/scripts/test_reset.lua
@@ -1,0 +1,642 @@
+local script_path = debug.getinfo(1, "S").source:sub(2)
+local project_root = vim.fn.fnamemodify(script_path, ":p:h:h")
+vim.opt.runtimepath:append(project_root)
+
+local function assert_true(condition, message)
+	if not condition then
+		error(message, 2)
+	end
+end
+
+local function assert_equals(actual, expected, message)
+	if actual ~= expected then
+		error(
+			("%s (expected=%s, actual=%s)"):format(
+				message, vim.inspect(expected), vim.inspect(actual)
+			),
+			2
+		)
+	end
+end
+
+local function contains(list, value)
+	for _, item in ipairs(list) do
+		if item == value then
+			return true
+		end
+	end
+	return false
+end
+
+local unpack_fn = table.unpack or unpack
+
+local function wait_async(start, timeout_ms)
+	local done = false
+	local result = nil
+
+	start(function(...)
+		result = { ... }
+		done = true
+	end)
+
+	local ok = vim.wait(timeout_ms or 5000, function()
+		return done
+	end, 10)
+	assert_true(ok, "async callback timed out")
+	return unpack_fn(result)
+end
+
+local function run_git(repo_dir, args, should_succeed)
+	local cmd = { "git" }
+	vim.list_extend(cmd, args)
+	local output = ""
+	local code = 1
+
+	if vim.system then
+		local result = vim.system(cmd, { cwd = repo_dir, text = true }):wait()
+		output = (result.stdout or "") .. (result.stderr or "")
+		code = result.code or 1
+	else
+		local previous = vim.fn.getcwd()
+		vim.fn.chdir(repo_dir)
+		output = vim.fn.system(cmd)
+		code = vim.v.shell_error
+		vim.fn.chdir(previous)
+	end
+	if should_succeed == nil then
+		should_succeed = true
+	end
+	if should_succeed and code ~= 0 then
+		error(
+			("git command failed (%s): %s"):format(
+				table.concat(cmd, " "), output
+			),
+			2
+		)
+	end
+	return output, code
+end
+
+local function write_file(path, lines)
+	vim.fn.writefile(lines, path)
+end
+
+local function assert_mapping(lhs, expected_rhs, message)
+	local mapping = vim.fn.maparg(lhs, "n", false, true)
+	assert_true(
+		type(mapping) == "table" and mapping.rhs == expected_rhs, message
+	)
+end
+
+local passed = 0
+local failed = 0
+local test_name = ""
+
+local function test(name, fn)
+	test_name = name
+	local ok, err = pcall(fn)
+	if ok then
+		passed = passed + 1
+		print(("  PASS: %s"):format(name))
+	else
+		failed = failed + 1
+		print(("  FAIL: %s\n        %s"):format(name, tostring(err)))
+	end
+end
+
+print("=== Gitflow Reset Panel Tests ===")
+
+-- Set up a temp repo with multiple commits and a main branch
+local repo_dir = vim.fn.tempname()
+assert_equals(
+	vim.fn.mkdir(repo_dir, "p"), 1,
+	"temp repo directory should be created"
+)
+
+run_git(repo_dir, { "init", "-b", "main" })
+run_git(repo_dir, { "config", "user.email", "reset@example.com" })
+run_git(repo_dir, { "config", "user.name", "Reset Tester" })
+
+write_file(repo_dir .. "/file.txt", { "line1" })
+run_git(repo_dir, { "add", "file.txt" })
+run_git(repo_dir, { "commit", "-m", "initial commit" })
+
+write_file(repo_dir .. "/file.txt", { "line1", "line2" })
+run_git(repo_dir, { "add", "file.txt" })
+run_git(repo_dir, { "commit", "-m", "second commit" })
+
+-- Create a feature branch with additional commits
+run_git(repo_dir, { "checkout", "-b", "feature" })
+
+write_file(repo_dir .. "/file.txt", { "line1", "line2", "line3" })
+run_git(repo_dir, { "add", "file.txt" })
+run_git(repo_dir, { "commit", "-m", "feature commit 1" })
+
+write_file(repo_dir .. "/file.txt", { "line1", "line2", "line3", "line4" })
+run_git(repo_dir, { "add", "file.txt" })
+run_git(repo_dir, { "commit", "-m", "feature commit 2" })
+
+local original_cwd = vim.fn.getcwd()
+vim.fn.chdir(repo_dir)
+
+local gitflow = require("gitflow")
+local cfg = gitflow.setup({
+	ui = {
+		default_layout = "split",
+		split = {
+			orientation = "vertical",
+			size = 45,
+		},
+	},
+	git = {
+		log = {
+			count = 25,
+			format = "%h %s",
+		},
+	},
+})
+
+-- ─── Module loading tests ───
+
+test("git/reset module loads successfully", function()
+	local git_reset = require("gitflow.git.reset")
+	assert_true(type(git_reset) == "table", "module should be a table")
+	assert_true(
+		type(git_reset.list_commits) == "function",
+		"list_commits should be a function"
+	)
+	assert_true(
+		type(git_reset.find_merge_base) == "function",
+		"find_merge_base should be a function"
+	)
+	assert_true(
+		type(git_reset.reset) == "function",
+		"reset should be a function"
+	)
+end)
+
+test("panels/reset module loads successfully", function()
+	local reset_panel = require("gitflow.panels.reset")
+	assert_true(type(reset_panel) == "table", "module should be a table")
+	assert_true(
+		type(reset_panel.open) == "function",
+		"open should be a function"
+	)
+	assert_true(
+		type(reset_panel.close) == "function",
+		"close should be a function"
+	)
+	assert_true(
+		type(reset_panel.refresh) == "function",
+		"refresh should be a function"
+	)
+	assert_true(
+		type(reset_panel.is_open) == "function",
+		"is_open should be a function"
+	)
+	assert_true(
+		type(reset_panel.select_under_cursor) == "function",
+		"select_under_cursor should be a function"
+	)
+	assert_true(
+		type(reset_panel.select_by_position) == "function",
+		"select_by_position should be a function"
+	)
+	assert_true(
+		type(reset_panel.reset_under_cursor) == "function",
+		"reset_under_cursor should be a function"
+	)
+end)
+
+-- ─── Subcommand registration tests ───
+
+test("reset subcommand is registered", function()
+	local commands = require("gitflow.commands")
+	local all = commands.complete("")
+	assert_true(
+		contains(all, "reset"),
+		"reset should appear in subcommand completions"
+	)
+end)
+
+test("reset subcommand has correct description", function()
+	local commands = require("gitflow.commands")
+	assert_true(
+		commands.subcommands.reset ~= nil,
+		"reset subcommand should exist"
+	)
+	assert_equals(
+		commands.subcommands.reset.description,
+		"Open git reset panel",
+		"reset subcommand description should match"
+	)
+end)
+
+-- ─── Keybinding tests ───
+
+test("default reset keybinding is gR", function()
+	assert_equals(
+		cfg.keybindings.reset, "gR",
+		"default reset keybinding should be gR"
+	)
+end)
+
+test("GitflowReset plug mapping is registered", function()
+	assert_mapping(
+		"<Plug>(GitflowReset)",
+		"<Cmd>Gitflow reset<CR>",
+		"reset plug keymap should be registered"
+	)
+end)
+
+test("default reset keymap maps to plug", function()
+	assert_mapping(
+		cfg.keybindings.reset,
+		"<Plug>(GitflowReset)",
+		"gR should map to <Plug>(GitflowReset)"
+	)
+end)
+
+-- ─── Highlight group tests ───
+
+test("GitflowResetMergeBase highlight group is defined", function()
+	local highlights = require("gitflow.highlights")
+	assert_true(
+		highlights.DEFAULT_GROUPS.GitflowResetMergeBase ~= nil,
+		"GitflowResetMergeBase should be in DEFAULT_GROUPS"
+	)
+	assert_equals(
+		highlights.DEFAULT_GROUPS.GitflowResetMergeBase.link,
+		"WarningMsg",
+		"GitflowResetMergeBase should link to WarningMsg"
+	)
+end)
+
+test("GitflowResetMergeBase highlight is applied after setup", function()
+	local hl = vim.api.nvim_get_hl(0, { name = "GitflowResetMergeBase" })
+	assert_true(
+		hl ~= nil and (hl.link ~= nil or next(hl) ~= nil),
+		"GitflowResetMergeBase highlight should be applied"
+	)
+end)
+
+-- ─── Icon tests ───
+
+test("reset icon is registered in palette category", function()
+	local icons_mod = require("gitflow.icons")
+	local icon = icons_mod.get("palette", "reset")
+	assert_true(
+		icon ~= nil and icon ~= "",
+		"reset icon should be available in palette category"
+	)
+end)
+
+-- ─── Git operation tests ───
+
+test("list_commits returns commit entries", function()
+	local git_reset = require("gitflow.git.reset")
+	local err, entries = wait_async(function(done)
+		git_reset.list_commits({ count = 10 }, function(e, ents)
+			done(e, ents)
+		end)
+	end)
+
+	assert_true(err == nil, "list_commits should not error")
+	assert_true(
+		type(entries) == "table" and #entries > 0,
+		"should return at least one entry"
+	)
+	assert_true(
+		entries[1].sha ~= nil and entries[1].sha ~= "",
+		"entry should have a sha"
+	)
+	assert_true(
+		entries[1].short_sha ~= nil and entries[1].short_sha ~= "",
+		"entry should have a short_sha"
+	)
+	assert_true(
+		entries[1].summary ~= nil and entries[1].summary ~= "",
+		"entry should have a summary"
+	)
+end)
+
+test("find_merge_base returns SHA on diverged branch", function()
+	local git_reset = require("gitflow.git.reset")
+	local err, sha = wait_async(function(done)
+		git_reset.find_merge_base({}, function(e, s)
+			done(e, s)
+		end)
+	end)
+
+	assert_true(err == nil, "find_merge_base should not error")
+	assert_true(
+		type(sha) == "string" and #sha > 0,
+		"merge-base SHA should be a non-empty string"
+	)
+end)
+
+-- ─── Panel lifecycle tests ───
+
+test("reset panel opens and shows commits", function()
+	local reset_panel = require("gitflow.panels.reset")
+	reset_panel.open(cfg)
+
+	vim.wait(2000, function()
+		if not reset_panel.state.bufnr then
+			return false
+		end
+		if not vim.api.nvim_buf_is_valid(reset_panel.state.bufnr) then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(
+			reset_panel.state.bufnr, 0, -1, false
+		)
+		return #lines > 1 and not lines[1]:find("Loading", 1, true)
+	end, 50)
+
+	assert_true(reset_panel.is_open(), "reset panel should be open")
+	assert_true(
+		reset_panel.state.bufnr ~= nil,
+		"bufnr should be set"
+	)
+	assert_true(
+		reset_panel.state.winid ~= nil,
+		"winid should be set"
+	)
+
+	local lines = vim.api.nvim_buf_get_lines(
+		reset_panel.state.bufnr, 0, -1, false
+	)
+	assert_true(#lines > 2, "should have rendered commit lines")
+
+	-- Check that at least one line has a commit entry marker
+	local has_entry = false
+	for _, line in ipairs(lines) do
+		if line:find("feature commit", 1, true) then
+			has_entry = true
+			break
+		end
+	end
+	assert_true(has_entry, "should contain a commit summary line")
+
+	reset_panel.close()
+end)
+
+test("reset panel keymaps are set on buffer", function()
+	local reset_panel = require("gitflow.panels.reset")
+	reset_panel.open(cfg)
+
+	vim.wait(1000, function()
+		return reset_panel.state.bufnr ~= nil
+			and vim.api.nvim_buf_is_valid(reset_panel.state.bufnr)
+	end, 50)
+
+	local bufnr = reset_panel.state.bufnr
+	assert_true(bufnr ~= nil, "bufnr should exist")
+
+	local keymaps = vim.api.nvim_buf_get_keymap(bufnr, "n")
+	local found_keys = {}
+	for _, km in ipairs(keymaps) do
+		found_keys[km.lhs] = true
+	end
+
+	assert_true(found_keys["<CR>"] ~= nil, "CR keymap should be set")
+	assert_true(found_keys["r"] ~= nil, "r keymap should be set")
+	assert_true(found_keys["q"] ~= nil, "q keymap should be set")
+	assert_true(found_keys["S"] ~= nil, "S keymap should be set")
+	assert_true(found_keys["H"] ~= nil, "H keymap should be set")
+	assert_true(found_keys["1"] ~= nil, "1 keymap should be set")
+	assert_true(found_keys["9"] ~= nil, "9 keymap should be set")
+
+	reset_panel.close()
+end)
+
+test("reset panel close cleans up state", function()
+	local reset_panel = require("gitflow.panels.reset")
+	reset_panel.open(cfg)
+
+	vim.wait(500, function()
+		return reset_panel.state.bufnr ~= nil
+	end, 50)
+
+	reset_panel.close()
+
+	assert_true(
+		reset_panel.state.bufnr == nil,
+		"bufnr should be nil after close"
+	)
+	assert_true(
+		reset_panel.state.winid == nil,
+		"winid should be nil after close"
+	)
+	assert_true(
+		not reset_panel.is_open(),
+		"is_open should return false after close"
+	)
+end)
+
+test("merge-base commit is highlighted", function()
+	local reset_panel = require("gitflow.panels.reset")
+	reset_panel.open(cfg)
+
+	vim.wait(2000, function()
+		if not reset_panel.state.bufnr then
+			return false
+		end
+		if not vim.api.nvim_buf_is_valid(reset_panel.state.bufnr) then
+			return false
+		end
+		return reset_panel.state.merge_base_sha ~= nil
+	end, 50)
+
+	assert_true(
+		reset_panel.state.merge_base_sha ~= nil,
+		"merge_base_sha should be set after render"
+	)
+
+	-- Check that highlight extmarks were applied
+	local bufnr = reset_panel.state.bufnr
+	local ns = vim.api.nvim_create_namespace("gitflow_reset_hl")
+	local extmarks = vim.api.nvim_buf_get_extmarks(
+		bufnr, ns, 0, -1, { details = true }
+	)
+	assert_true(
+		#extmarks > 0,
+		"should have highlight extmarks applied"
+	)
+
+	-- Look for the merge-base highlight specifically
+	local has_merge_base_hl = false
+	for _, mark in ipairs(extmarks) do
+		local details = mark[4]
+		if details and details.hl_group == "GitflowResetMergeBase" then
+			has_merge_base_hl = true
+			break
+		end
+	end
+	assert_true(
+		has_merge_base_hl,
+		"GitflowResetMergeBase highlight should be applied to"
+			.. " the merge-base line"
+	)
+
+	reset_panel.close()
+end)
+
+test("position numbers are rendered for first 9 commits", function()
+	local reset_panel = require("gitflow.panels.reset")
+	reset_panel.open(cfg)
+
+	vim.wait(2000, function()
+		if not reset_panel.state.bufnr then
+			return false
+		end
+		if not vim.api.nvim_buf_is_valid(reset_panel.state.bufnr) then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(
+			reset_panel.state.bufnr, 0, -1, false
+		)
+		return #lines > 1 and not lines[1]:find("Loading", 1, true)
+	end, 50)
+
+	local lines = vim.api.nvim_buf_get_lines(
+		reset_panel.state.bufnr, 0, -1, false
+	)
+
+	local has_numbered = false
+	for _, line in ipairs(lines) do
+		if line:find("%[1%]", 1, false) then
+			has_numbered = true
+			break
+		end
+	end
+	assert_true(
+		has_numbered,
+		"first commit should have [1] position marker"
+	)
+
+	reset_panel.close()
+end)
+
+test("line_entries map is populated after render", function()
+	local reset_panel = require("gitflow.panels.reset")
+	reset_panel.open(cfg)
+
+	vim.wait(2000, function()
+		if not reset_panel.state.bufnr then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(
+			reset_panel.state.bufnr, 0, -1, false
+		)
+		return #lines > 1 and not lines[1]:find("Loading", 1, true)
+	end, 50)
+
+	local entry_count = 0
+	for _ in pairs(reset_panel.state.line_entries) do
+		entry_count = entry_count + 1
+	end
+	assert_true(
+		entry_count >= 4,
+		"should have at least 4 commit entries in line_entries"
+	)
+
+	reset_panel.close()
+end)
+
+test("git reset --soft executes successfully", function()
+	-- Get current HEAD
+	local head_sha = vim.trim(
+		run_git(repo_dir, { "rev-parse", "HEAD" })
+	)
+	local parent_sha = vim.trim(
+		run_git(repo_dir, { "rev-parse", "HEAD~1" })
+	)
+
+	local git_reset = require("gitflow.git.reset")
+	local err = wait_async(function(done)
+		git_reset.reset(parent_sha, "soft", function(e, _)
+			done(e)
+		end)
+	end)
+
+	assert_true(err == nil, "soft reset should not error")
+
+	-- Verify HEAD moved
+	local new_head = vim.trim(
+		run_git(repo_dir, { "rev-parse", "HEAD" })
+	)
+	assert_equals(
+		new_head, parent_sha,
+		"HEAD should point to the parent commit after soft reset"
+	)
+
+	-- Restore original HEAD for subsequent tests
+	run_git(repo_dir, { "reset", "--hard", head_sha })
+end)
+
+test("git reset --hard executes successfully", function()
+	local head_sha = vim.trim(
+		run_git(repo_dir, { "rev-parse", "HEAD" })
+	)
+	local parent_sha = vim.trim(
+		run_git(repo_dir, { "rev-parse", "HEAD~1" })
+	)
+
+	local git_reset = require("gitflow.git.reset")
+	local err = wait_async(function(done)
+		git_reset.reset(parent_sha, "hard", function(e, _)
+			done(e)
+		end)
+	end)
+
+	assert_true(err == nil, "hard reset should not error")
+
+	local new_head = vim.trim(
+		run_git(repo_dir, { "rev-parse", "HEAD" })
+	)
+	assert_equals(
+		new_head, parent_sha,
+		"HEAD should point to the parent commit after hard reset"
+	)
+
+	-- Restore
+	run_git(repo_dir, { "reset", "--hard", head_sha })
+end)
+
+test("config validation accepts reset keybinding", function()
+	local config = require("gitflow.config")
+	local test_cfg = config.defaults()
+	test_cfg.keybindings.reset = "gR"
+	local ok = pcall(config.validate, test_cfg)
+	assert_true(ok, "config validation should pass with reset keybinding")
+end)
+
+test("dispatch reset subcommand returns expected message", function()
+	local commands = require("gitflow.commands")
+	local result = commands.dispatch({ "reset" }, cfg)
+	-- The panel opens asynchronously, but dispatch returns a message
+	assert_true(
+		type(result) == "string",
+		"dispatch should return a string"
+	)
+
+	-- Clean up the panel
+	local reset_panel = require("gitflow.panels.reset")
+	vim.wait(500, function()
+		return reset_panel.state.bufnr ~= nil
+	end, 50)
+	reset_panel.close()
+end)
+
+-- ─── Cleanup ───
+
+vim.fn.chdir(original_cwd)
+vim.fn.delete(repo_dir, "rf")
+
+print(("=== Results: %d passed, %d failed ==="):format(passed, failed))
+if failed > 0 then
+	vim.cmd("cquit! 1")
+end
+vim.cmd("qall!")


### PR DESCRIPTION
## Summary

Closes #139

- **New `lua/gitflow/git/reset.lua`**: Async git operations module with `list_commits()` (reuses git log), `find_merge_base()` (tries main → master → origin/HEAD fallback), and `reset(sha, mode)` for soft/hard reset execution.
- **New `lua/gitflow/panels/reset.lua`**: Floating window panel following existing panel patterns (log/stash). Displays last N commits with position markers `[1]`-`[9]`, highlights the merge-base commit with `GitflowResetMergeBase` (linked to `WarningMsg`). Keybindings: `<CR>` cursor select, `1`-`9` positional select, `S` soft reset, `H` hard reset, `r` refresh, `q` close. Confirmation step prompts Soft/Hard/Cancel (or confirms the specific mode with default=Cancel for hard reset).
- **`commands.lua`**: Registered `:Gitflow reset` subcommand, `<Plug>(GitflowReset)` mapping, close handler integration.
- **`config.lua`**: Default keybinding `gR` for reset.
- **`highlights.lua`**: Added `GitflowResetMergeBase = { link = "WarningMsg" }`.
- **`icons.lua`**: Added `reset` icon to palette category.
- **`KEYBINDINGS.md`**: Documented Reset Panel section with all buffer-local bindings.

### Testing/Installing/Reviewing

**Run tests:**
```
nvim --headless -u NONE -l scripts/test_reset.lua
```

**22 tests covering:**
- Module loading (git/reset, panels/reset)
- Subcommand registration and completion
- Default keybinding `gR` and plug mapping
- `GitflowResetMergeBase` highlight group definition and application
- Reset icon in palette category
- `list_commits` returns structured entries
- `find_merge_base` returns SHA on diverged branch
- Panel open/close lifecycle and state cleanup
- Buffer-local keymaps (`<CR>`, `1`-`9`, `S`, `H`, `r`, `q`)
- Merge-base highlight extmark application
- Position number markers `[1]`-`[9]` rendering
- `line_entries` map population
- `git reset --soft` and `git reset --hard` execution
- Config validation with reset keybinding
- Dispatch subcommand integration

**Regression validation:** Stages 1, 6, 8 (highlights), 10 (palette), and unified theme tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)