### PR TITLE
Issue #132: Implement keybind and functionallity for global git stash pop

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -23,6 +23,7 @@ Normal-mode mappings available in any buffer. Configured via
 | `gl` | Open log panel | `log` |
 | `gS` | Open stash list | `stash` |
 | `gZ` | Stash push (with prompt) | `stash_push` |
+| `gX` | Stash pop | `stash_pop` |
 | `<leader>gb` | Open branch list | `branch` |
 | `<leader>gI` | Open issue list | `issue` |
 | `<leader>gR` | Open PR list | `pr` |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ require("gitflow").setup({
     log        = "gl",
     stash      = "gS",
     stash_push = "gZ",
+    stash_pop  = "gX",
     branch     = "<leader>gb",
     issue      = "<leader>gI",
     pr         = "<leader>gR",
@@ -236,6 +237,7 @@ instructions.
 | `gl` | Log |
 | `gS` | Stash list |
 | `gZ` | Stash push |
+| `gX` | Stash pop |
 | `<leader>gb` | Branch list |
 | `<leader>gI` | Issues |
 | `<leader>gR` | Pull requests |

--- a/doc/gitflow.txt
+++ b/doc/gitflow.txt
@@ -102,6 +102,7 @@ Default keybindings:
     log             gl                  <Plug>(GitflowLog)
     stash           gS                  <Plug>(GitflowStash)
     stash_push      gZ                  <Plug>(GitflowStashPush)
+    stash_pop       gX                  <Plug>(GitflowStashPop)
     branch          <leader>gb          <Plug>(GitflowBranch)
     issue           <leader>gI          <Plug>(GitflowIssue)
     pr              <leader>gR          <Plug>(GitflowPr)

--- a/lua/gitflow/commands.lua
+++ b/lua/gitflow/commands.lua
@@ -2129,6 +2129,7 @@ function M.setup(cfg)
 	vim.keymap.set("n", "<Plug>(GitflowLog)", "<Cmd>Gitflow log<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowStash)", "<Cmd>Gitflow stash list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowStashPush)", "<Cmd>Gitflow stash push<CR>", { silent = true })
+	vim.keymap.set("n", "<Plug>(GitflowStashPop)", "<Cmd>Gitflow stash pop<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowIssue)", "<Cmd>Gitflow issue list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowPr)", "<Cmd>Gitflow pr list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowLabel)", "<Cmd>Gitflow label list<CR>", { silent = true })
@@ -2151,6 +2152,7 @@ function M.setup(cfg)
 		log = "<Plug>(GitflowLog)",
 		stash = "<Plug>(GitflowStash)",
 		stash_push = "<Plug>(GitflowStashPush)",
+		stash_pop = "<Plug>(GitflowStashPop)",
 		issue = "<Plug>(GitflowIssue)",
 		pr = "<Plug>(GitflowPr)",
 		label = "<Plug>(GitflowLabel)",

--- a/lua/gitflow/config.lua
+++ b/lua/gitflow/config.lua
@@ -80,6 +80,7 @@ function M.defaults()
 			log = "gl",
 			stash = "gS",
 			stash_push = "gZ",
+			stash_pop = "gX",
 			branch = "<leader>gb",
 			issue = "<leader>gi",
 			pr = "<leader>gr",

--- a/scripts/test_stage2.lua
+++ b/scripts/test_stage2.lua
@@ -172,6 +172,18 @@ assert_mapping(
 	"default stash push keymap should be registered"
 )
 
+assert_equals(cfg.keybindings.stash_pop, "gX", "default stash pop keybinding should exist")
+assert_mapping(
+	"<Plug>(GitflowStashPop)",
+	"<Cmd>Gitflow stash pop<CR>",
+	"stash pop plug keymap should be registered"
+)
+assert_mapping(
+	cfg.keybindings.stash_pop,
+	"<Plug>(GitflowStashPop)",
+	"default stash pop keymap should be registered"
+)
+
 local commands = require("gitflow.commands")
 local all_subcommands = commands.complete("")
 for _, expected in ipairs({


### PR DESCRIPTION
Closes #132

## Summary

- **What changed**: Added global `gX` keybinding (`config.keybindings.stash_pop`) that maps to `<Plug>(GitflowStashPop)` and dispatches `:Gitflow stash pop` from any buffer.
- **Why**: Users could globally stash push with `gZ` but had to open the stash panel to pop. This adds symmetry by exposing stash pop as a global keybind.
- **Key decisions**: Reused the existing `stash pop` command dispatch and `git_stash.pop()` implementation — only wiring was needed (config default, Plug mapping, key-to-plug entry).

### Files changed
- `lua/gitflow/config.lua` — added `stash_pop = "gX"` to keybinding defaults
- `lua/gitflow/commands.lua` — added `<Plug>(GitflowStashPop)` mapping and `stash_pop` entry in `key_to_plug` table
- `scripts/test_stage2.lua` — added keybinding wiring assertions for stash pop
- `KEYBINDINGS.md`, `README.md`, `doc/gitflow.txt` — documented new keybinding

## Test plan
- [x] Verify `stash_pop` default is `gX` in config
- [x] Verify `<Plug>(GitflowStashPop)` maps to `<Cmd>Gitflow stash pop<CR>`
- [x] Verify `gX` maps to `<Plug>(GitflowStashPop)`
- [x] Stage 1 smoke tests pass
- [x] Stage 6, 8 highlights, and 10 palette tests pass (no regressions)
- [x] Stage 2 pre-existing failure unchanged (unrelated push keymap expectation drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)