### PR TITLE
Issue #176: [Phase 5: #166] E2E conflict resolution & full repo flow tests

### DIFF
--- a/tests/e2e/gear_system_spec.lua
+++ b/tests/e2e/gear_system_spec.lua
@@ -372,13 +372,34 @@ T.run_suite("E2E: Conflict Resolution UI", {
 				end,
 			},
 		}, function()
-			conflict_view.open(path, { cfg = cfg })
-			T.drain_jobs(3000)
+			with_conflicts(path, function()
+				conflict_panel.open(cfg)
+				T.drain_jobs(3000)
+
+				local bufnr = ui.buffer.get("conflict")
+				T.assert_true(bufnr ~= nil, "conflict buffer should exist")
+
+				local line_no = T.buf_find_line(bufnr, path)
+				T.assert_true(
+					line_no ~= nil,
+					"conflict panel should render selected conflicted file"
+				)
+
+				local winid = conflict_panel.state.winid
+				T.assert_true(
+					winid ~= nil and vim.api.nvim_win_is_valid(winid),
+					"conflict panel window should be valid"
+				)
+				vim.api.nvim_set_current_win(winid)
+				vim.api.nvim_win_set_cursor(winid, { line_no, 0 })
+				T.feedkeys("<CR>")
+				T.drain_jobs(3000)
+			end)
 		end)
 
 		T.assert_true(
 			conflict_view.is_open(),
-			"3-way conflict view should be open"
+			"3-way conflict view should open from conflict panel <CR>"
 		)
 		T.assert_true(
 			conflict_view.state.active,

--- a/tests/fixtures/bin/git
+++ b/tests/fixtures/bin/git
@@ -264,6 +264,16 @@ DIFF
     # add produces no stdout on success
     ;;
 
+  # ── commit ────────────────────────────────────────────────────────────
+  commit)
+    if [ "$fail_cmd" = "commit" ]; then
+      echo "error: commit failed" >&2
+      exit 1
+    fi
+    printf '[main abc1234] Test commit\n'
+    printf ' 1 file changed, 1 insertion(+)\n'
+    ;;
+
   # ── reset ─────────────────────────────────────────────────────────────
   reset)
     if [ "$fail_cmd" = "reset" ]; then


### PR DESCRIPTION
Closes #176

## Summary

- **`tests/e2e/gear_system_spec.lua`** (24 tests): Full coverage of the 3-way conflict resolution UI — panel open/close, conflicted file list from git stub, panel keymaps, `parse_markers` hunk extraction, LOCAL/BASE/REMOTE pane existence and read-only state, hunk navigation (`]x`/`[x`) with wrap-around, resolve LOCAL (`1`), BASE (`2`), REMOTE (`3`) sides, resolve-all (`a`) with side prompt, manual edit mode (`e`), continue merge (`C`), abort operation (`A`), window/tab cleanup after close, scrollbind on top panes, highlight extmarks, and on_closed callback.

- **`tests/e2e/full_repo_flow_spec.lua`** (24 tests): End-to-end lifecycle exercising the entire plugin without restart — main UI open/close, status panel with file listing and staging keymaps, PR creation via `gh pr create`, PR list from fixture, PR view dispatch, review panel with keymaps and PR tracking, inline comment pending list, review approve via `gh pr review --approve`, conflict panel file listing, conflict resolution writing correct content, sequential panel operations, git/gh stub invocation ordering, no orphaned windows after full lifecycle, command dispatch coverage, and conflict panel→3-way view→close round-trip.

- **Git stub enhancements**: `diff --name-only --diff-filter=U` (conflict list via `$GITFLOW_GIT_CONFLICTS`), `rev-parse --git-dir`, `rev-parse @{upstream}` returning `origin/main`, `show :1:/:2:/:3:` (merge stage versions), `merge/rebase/cherry-pick --continue/--abort` success paths.

### Testing/Installing/Reviewing

```bash
# Run new Phase 5 tests
nvim --headless -u tests/minimal_init.lua -l tests/e2e/gear_system_spec.lua
nvim --headless -u tests/minimal_init.lua -l tests/e2e/full_repo_flow_spec.lua

# Run all 10 E2E suites (214 total tests)
for spec in tests/e2e_smoke_test.lua tests/e2e/open_ui_spec.lua tests/e2e/commands_spec.lua tests/e2e/keybindings_spec.lua tests/e2e/pr_create_spec.lua tests/e2e/pr_review_spec.lua tests/e2e/error_paths_spec.lua tests/e2e/async_spec.lua tests/e2e/gear_system_spec.lua tests/e2e/full_repo_flow_spec.lua; do
  nvim --headless -u tests/minimal_init.lua -l "$spec"
done
```

Expected: 214 tests pass across 10 suites (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)