### PR TITLE
Issue #182: Update test assertions to match current production defaults

### DIFF
--- a/scripts/test_stage3.lua
+++ b/scripts/test_stage3.lua
@@ -193,11 +193,15 @@ end, "branch panel should open")
 
 local branch_lines = vim.api.nvim_buf_get_lines(branch_panel.state.bufnr, 0, -1, false)
 assert_true(find_line(branch_lines, "Remote") ~= nil, "branch panel should render remote section")
-local expected_current = ("* %s (current)"):format(current_branch(repo_dir))
-assert_true(
-	find_line(branch_lines, expected_current) ~= nil,
-	"current branch should be indicated distinctly"
-)
+local current_name = current_branch(repo_dir)
+local current_found = false
+for _, line in ipairs(branch_lines) do
+	if line:find(current_name, 1, true) and line:find("(current)", 1, true) then
+		current_found = true
+		break
+	end
+end
+assert_true(current_found, "current branch should be indicated distinctly")
 
 local branch_maps = vim.api.nvim_buf_get_keymap(branch_panel.state.bufnr, "n")
 local required_maps = { ["<CR>"] = true, c = true, d = true, D = true, r = true, R = true, f = true, q = true }

--- a/scripts/test_stage4.lua
+++ b/scripts/test_stage4.lua
@@ -373,7 +373,7 @@ wait_until(function()
 		return false
 	end
 	local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-	return find_line(lines, "#1 [open] Stage4 issue") ~= nil
+	return find_line(lines, "Stage4 issue") ~= nil
 end, "issue list should render issue entries")
 
 local issue_buf = buffer.get("issues")
@@ -541,88 +541,51 @@ vim.o.wildcharm = original_wildcharm
 vim.o.wildmenu = original_wildmenu
 vim.o.wildmode = original_wildmode
 
--- Test: create_interactive labels prompt wires completion
-local create_prompt_count = 0
-local create_label_completion = nil
-local create_completion_fn_name = nil
-
-vim.ui.input = function(_, _)
-	error(
-		"create label prompt should not use vim.ui.input when completion is configured",
-		2
-	)
-end
-
-vim.fn.inputsave = function()
-	return 1
-end
-vim.fn.inputrestore = function()
-	return 1
-end
-
-vim.fn.input = function(opts)
-	create_prompt_count = create_prompt_count + 1
-	if create_prompt_count == 3 then
-		-- This is the labels prompt (title=1, body=2, labels=3)
-		create_label_completion = opts.completion
-		assert_true(
-			type(create_label_completion) == "string",
-			"create labels prompt should configure completion"
-		)
-
-		create_completion_fn_name =
-			create_label_completion:match("^customlist,v:lua%.([%w_]+)$")
-		assert_true(
-			create_completion_fn_name ~= nil,
-			"create labels prompt should use custom completion"
-		)
-		assert_true(
-			type(_G[create_completion_fn_name]) == "function",
-			"create labels custom completion function should exist"
-		)
-
-		local candidates = _G[create_completion_fn_name]("b", "", 0)
-		assert_true(
-			contains(candidates, "bug"),
-			"create labels completion should suggest matching label"
-		)
-
-		local no_sign = _G[create_completion_fn_name]("+b", "", 0)
-		assert_true(
-			not contains(no_sign, "+bug"),
-			"create labels completion should not handle +/- sign prefixes"
-		)
-
-		local multi = _G[create_completion_fn_name]("bug,d", "", 0)
-		assert_true(
-			contains(multi, "bug,docs"),
-			"create labels completion should support comma-separated values"
-		)
-		assert_true(
-			not contains(multi, "bug,bug"),
-			"create labels completion should exclude already-selected labels"
-		)
-
-		return "bug,docs"
-	end
-	return "test value"
-end
-
+-- Test: create_interactive opens a form-based float
 issues_panel.create_interactive()
 wait_until(function()
-	local lines = read_lines(gh_log)
-	return find_line(lines, "issue create") ~= nil
-end, "create_interactive should invoke gh issue create")
+	local wins = vim.api.nvim_list_wins()
+	for _, winid in ipairs(wins) do
+		local ok_w, wconfig = pcall(vim.api.nvim_win_get_config, winid)
+		if ok_w and wconfig.relative and wconfig.relative ~= "" then
+			local wbuf = vim.api.nvim_win_get_buf(winid)
+			local ft = vim.api.nvim_get_option_value("filetype", { buf = wbuf })
+			if ft == "gitflow-form" then
+				return true
+			end
+		end
+	end
+	return false
+end, "create_interactive should open form float", 2000)
 
+local create_form_buf = nil
+local create_form_lines = {}
+for _, winid in ipairs(vim.api.nvim_list_wins()) do
+	local ok_w, wconfig = pcall(vim.api.nvim_win_get_config, winid)
+	if ok_w and wconfig.relative and wconfig.relative ~= "" then
+		local wbuf = vim.api.nvim_win_get_buf(winid)
+		local ft = vim.api.nvim_get_option_value("filetype", { buf = wbuf })
+		if ft == "gitflow-form" then
+			create_form_buf = wbuf
+			create_form_lines = vim.api.nvim_buf_get_lines(wbuf, 0, -1, false)
+			pcall(vim.api.nvim_win_close, winid, true)
+			break
+		end
+	end
+end
+assert_true(create_form_buf ~= nil, "issue create form buffer should exist")
 assert_true(
-	create_completion_fn_name ~= nil and _G[create_completion_fn_name] == nil,
-	"create labels completion function should be cleaned up after input"
+	find_line(create_form_lines, "Title") ~= nil,
+	"issue create form should have Title field"
 )
-
-vim.ui.input = original_ui_input
-vim.fn.input = original_fn_input
-vim.fn.inputsave = original_inputsave
-vim.fn.inputrestore = original_inputrestore
+assert_true(
+	find_line(create_form_lines, "Body") ~= nil,
+	"issue create form should have Body field"
+)
+assert_true(
+	find_line(create_form_lines, "Labels") ~= nil,
+	"issue create form should have Labels field"
+)
 
 commands.dispatch({ "pr", "list", "open" }, cfg)
 wait_until(function()
@@ -640,7 +603,7 @@ wait_until(function()
 		return false
 	end
 	local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-	return find_line(lines, "#7 [open] Stage4 PR") ~= nil
+	return find_line(lines, "Stage4 PR") ~= nil
 end, "pr list should render pr entries")
 
 local pr_buf = buffer.get("prs")
@@ -649,7 +612,7 @@ assert_keymaps(pr_buf, { "<CR>", "c", "C", "L", "m", "o", "q" })
 assert_keymap_absent(pr_buf, "l")
 
 local pr_lines = vim.api.nvim_buf_get_lines(pr_buf, 0, -1, false)
-local pr_line = find_line(pr_lines, "#7 [open] Stage4 PR")
+local pr_line = find_line(pr_lines, "Stage4 PR")
 assert_true(pr_line ~= nil, "pr list line should exist")
 vim.api.nvim_set_current_win(pr_panel.state.winid)
 vim.api.nvim_win_set_cursor(pr_panel.state.winid, { pr_line, 0 })
@@ -777,7 +740,7 @@ wait_until(function()
 		return false
 	end
 	local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-	return find_line(lines, "#7 [open] Stage4 PR") ~= nil
+	return find_line(lines, "Stage4 PR") ~= nil
 end, "pr list should re-render before no-selection test")
 
 vim.api.nvim_set_current_win(pr_panel.state.winid)

--- a/scripts/test_stage7.lua
+++ b/scripts/test_stage7.lua
@@ -83,8 +83,12 @@ end
 
 local config = require("gitflow.config")
 local defaults = config.defaults()
-assert_equals(defaults.sync.pull_strategy, "rebase", "default pull strategy should be rebase")
-assert_equals(defaults.keybindings.palette, "<leader>gp", "default palette keybinding should exist")
+assert_equals(defaults.sync.pull_strategy, "merge", "default pull strategy should be merge")
+assert_equals(
+	defaults.keybindings.palette,
+	"<leader>go",
+	"default palette keybinding should exist"
+)
 assert_deep_equals(
 	defaults.quick_actions.quick_commit,
 	{ "commit" },

--- a/scripts/test_stage8_icons.lua
+++ b/scripts/test_stage8_icons.lua
@@ -33,8 +33,8 @@ assert_true(
 )
 assert_equals(
 	defaults.icons.enable,
-	false,
-	"icons.enable should default to false"
+	true,
+	"icons.enable should default to true"
 )
 
 -- validate accepts valid icons config


### PR DESCRIPTION
Closes #182

## Summary

- **test_stage8_icons.lua**: Updated `icons.enable` default assertion from `false` to `true` to match current production config
- **test_stage7.lua**: Updated `sync.pull_strategy` assertion from `"rebase"` to `"merge"` and `keybindings.palette` from `"<leader>gp"` to `"<leader>go"`
- **test_stage3.lua**: Made current branch indicator assertion icon-agnostic — now matches by branch name + `(current)` text instead of hardcoded `"* "` prefix, which breaks when Nerd Font icons are enabled
- **test_stage4.lua**: Updated issue/PR list entry assertions to match by title text instead of `"#N [open] Title"` format (icons replace `[open]` with Nerd Font glyphs); replaced stale sequential `vim.fn.input` create_interactive test with form-float assertions matching the current form-based creation flow

## Test plan

- [x] All 16 `scripts/test_stage*.lua` suites pass
- [x] `test_palette_accent_parity.lua`, `test_unified_theme.lua`, `test_reset.lua` pass
- [x] All 10 E2E suites pass (216 total tests)
- [x] No regressions in any previously-passing test

🤖 Generated with [Claude Code](https://claude.com/claude-code)