### PR TITLE
Issue #178: Add light colorscheme palette for background-aware highlights

### DIFF
--- a/lua/gitflow/highlights.lua
+++ b/lua/gitflow/highlights.lua
@@ -1,8 +1,8 @@
 local M = {}
 
---- Centralized color palette — single source of truth for accent colors.
+--- Dark palette — used when vim.o.background == "dark" (default).
 ---@type table<string, string>
-M.PALETTE = {
+M.PALETTE_DARK = {
 	accent_primary = "#56B6C2",
 	accent_secondary = "#DCA561",
 	separator_fg = "#3E4452",
@@ -10,72 +10,104 @@ M.PALETTE = {
 	dark_fg = "#222222",
 	log_hash = "#E5C07B",
 	stash_ref = "#C678DD",
+	diff_file_header = "#E5C07B",
+	diff_hunk_header = "#C678DD",
+	diff_line_nr = "#5C6370",
 }
 
-M.DEFAULT_GROUPS = {
-	-- Diff / git state
-	GitflowAdded = { link = "DiffAdd" },
-	GitflowRemoved = { link = "DiffDelete" },
-	GitflowModified = { link = "DiffChange" },
-	-- Diff view — distinct styling for file headers, hunk headers, context
-	GitflowDiffFileHeader = { fg = "#E5C07B", bold = true },
-	GitflowDiffHunkHeader = { fg = "#C678DD", bold = true },
-	GitflowDiffContext = { link = "Comment" },
-	GitflowDiffLineNr = { fg = "#5C6370" },
-	GitflowStaged = { link = "DiffAdd" },
-	GitflowUnstaged = { link = "DiffChange" },
-	GitflowUntracked = { link = "Comment" },
-	-- Conflict
-	GitflowConflictLocal = { link = "DiffAdd" },
-	GitflowConflictBase = { link = "DiffChange" },
-	GitflowConflictRemote = { link = "DiffDelete" },
-	GitflowConflictResolved = { link = "DiffText" },
-	-- Branch
-	GitflowBranchCurrent = { link = "Title" },
-	GitflowBranchRemote = { link = "Comment" },
-	-- PR state
-	GitflowPROpen = { link = "DiagnosticOk" },
-	GitflowPRMerged = { link = "Special" },
-	GitflowPRClosed = { link = "DiagnosticError" },
-	GitflowPRDraft = { link = "Comment" },
-	-- Issue state
-	GitflowIssueOpen = { link = "DiagnosticOk" },
-	GitflowIssueClosed = { link = "DiagnosticError" },
-	-- Review
-	GitflowReviewApproved = { link = "DiagnosticOk" },
-	GitflowReviewChangesRequested = { link = "WarningMsg" },
-	GitflowReviewComment = { link = "Comment" },
-	-- Log / Stash entry accents
-	GitflowLogHash = { fg = "#E5C07B", bold = true },
-	GitflowStashRef = { fg = "#C678DD", bold = true },
-	-- Window chrome — themed accent colors (cyan primary, gold secondary)
-	GitflowBorder = { fg = "#56B6C2" },
-	GitflowTitle = { fg = "#56B6C2", bold = true },
-	GitflowHeader = { fg = "#56B6C2", bold = true },
-	GitflowFooter = { fg = "#56B6C2", italic = true },
-	GitflowSeparator = { fg = "#3E4452" },
-	GitflowNormal = { link = "NormalFloat" },
-	GitflowPaletteSelection = { link = "PmenuSel" },
-	GitflowPaletteHeader = { bold = true, link = "Type" },
-	GitflowPaletteKeybind = { link = "Special" },
-	GitflowPaletteDescription = { link = "Comment" },
-	GitflowPaletteIndex = { link = "Number" },
-	GitflowPaletteCommand = { link = "Function" },
-	GitflowPaletteNormal = { link = "NormalFloat" },
-	GitflowPaletteHeaderBar = {
-		fg = "#222222", bg = "#DCA561", bold = true,
-	},
-	GitflowPaletteHeaderIcon = {
-		fg = "#56B6C2", bg = "#DCA561", bold = true,
-	},
-	GitflowPaletteEntryIcon = { fg = "#56B6C2" },
-	GitflowPaletteBackdrop = { bg = "#000000" },
-	-- Reset
-	GitflowResetMergeBase = { link = "WarningMsg" },
-	-- Form
-	GitflowFormLabel = { fg = "#56B6C2", bold = true },
-	GitflowFormActiveField = { link = "CursorLine" },
+--- Light palette — used when vim.o.background == "light".
+---@type table<string, string>
+M.PALETTE_LIGHT = {
+	accent_primary = "#0E7490",
+	accent_secondary = "#B5651D",
+	separator_fg = "#C8CCD4",
+	backdrop_bg = "#E8E8E8",
+	dark_fg = "#222222",
+	log_hash = "#986801",
+	stash_ref = "#A626A4",
+	diff_file_header = "#986801",
+	diff_hunk_header = "#A626A4",
+	diff_line_nr = "#999999",
 }
+
+--- Active palette — set by setup() based on vim.o.background.
+--- Defaults to dark palette until setup() is called.
+---@type table<string, string>
+M.PALETTE = vim.deepcopy(M.PALETTE_DARK)
+
+--- Build default highlight groups from the given palette.
+---@param palette table<string, string>
+---@return table<string, table>
+local function build_default_groups(palette)
+	return {
+		-- Diff / git state
+		GitflowAdded = { link = "DiffAdd" },
+		GitflowRemoved = { link = "DiffDelete" },
+		GitflowModified = { link = "DiffChange" },
+		-- Diff view — distinct styling for file headers, hunk headers, context
+		GitflowDiffFileHeader = { fg = palette.diff_file_header, bold = true },
+		GitflowDiffHunkHeader = { fg = palette.diff_hunk_header, bold = true },
+		GitflowDiffContext = { link = "Comment" },
+		GitflowDiffLineNr = { fg = palette.diff_line_nr },
+		GitflowStaged = { link = "DiffAdd" },
+		GitflowUnstaged = { link = "DiffChange" },
+		GitflowUntracked = { link = "Comment" },
+		-- Conflict
+		GitflowConflictLocal = { link = "DiffAdd" },
+		GitflowConflictBase = { link = "DiffChange" },
+		GitflowConflictRemote = { link = "DiffDelete" },
+		GitflowConflictResolved = { link = "DiffText" },
+		-- Branch
+		GitflowBranchCurrent = { link = "Title" },
+		GitflowBranchRemote = { link = "Comment" },
+		-- PR state
+		GitflowPROpen = { link = "DiagnosticOk" },
+		GitflowPRMerged = { link = "Special" },
+		GitflowPRClosed = { link = "DiagnosticError" },
+		GitflowPRDraft = { link = "Comment" },
+		-- Issue state
+		GitflowIssueOpen = { link = "DiagnosticOk" },
+		GitflowIssueClosed = { link = "DiagnosticError" },
+		-- Review
+		GitflowReviewApproved = { link = "DiagnosticOk" },
+		GitflowReviewChangesRequested = { link = "WarningMsg" },
+		GitflowReviewComment = { link = "Comment" },
+		-- Log / Stash entry accents
+		GitflowLogHash = { fg = palette.log_hash, bold = true },
+		GitflowStashRef = { fg = palette.stash_ref, bold = true },
+		-- Window chrome — themed accent colors
+		GitflowBorder = { fg = palette.accent_primary },
+		GitflowTitle = { fg = palette.accent_primary, bold = true },
+		GitflowHeader = { fg = palette.accent_primary, bold = true },
+		GitflowFooter = { fg = palette.accent_primary, italic = true },
+		GitflowSeparator = { fg = palette.separator_fg },
+		GitflowNormal = { link = "NormalFloat" },
+		GitflowPaletteSelection = { link = "PmenuSel" },
+		GitflowPaletteHeader = { bold = true, link = "Type" },
+		GitflowPaletteKeybind = { link = "Special" },
+		GitflowPaletteDescription = { link = "Comment" },
+		GitflowPaletteIndex = { link = "Number" },
+		GitflowPaletteCommand = { link = "Function" },
+		GitflowPaletteNormal = { link = "NormalFloat" },
+		GitflowPaletteHeaderBar = {
+			fg = palette.dark_fg, bg = palette.accent_secondary, bold = true,
+		},
+		GitflowPaletteHeaderIcon = {
+			fg = palette.accent_primary, bg = palette.accent_secondary,
+			bold = true,
+		},
+		GitflowPaletteEntryIcon = { fg = palette.accent_primary },
+		GitflowPaletteBackdrop = { bg = palette.backdrop_bg },
+		-- Reset
+		GitflowResetMergeBase = { link = "WarningMsg" },
+		-- Form
+		GitflowFormLabel = { fg = palette.accent_primary, bold = true },
+		GitflowFormActiveField = { link = "CursorLine" },
+	}
+end
+
+--- Current default groups — rebuilt by setup() for background-aware palettes.
+M.DEFAULT_GROUPS = build_default_groups(M.PALETTE_DARK)
 
 ---Create or retrieve a dynamic highlight group for a label hex color.
 ---@param hex_color string  6-digit hex (with or without leading #)
@@ -101,6 +133,12 @@ end
 ---@param user_overrides table<string, table>|nil
 function M.setup(user_overrides)
 	local overrides = type(user_overrides) == "table" and user_overrides or {}
+
+	-- Select palette based on vim.o.background
+	local palette = vim.o.background == "light"
+		and M.PALETTE_LIGHT or M.PALETTE_DARK
+	M.PALETTE = vim.deepcopy(palette)
+	M.DEFAULT_GROUPS = build_default_groups(palette)
 
 	for group, default_attrs in pairs(M.DEFAULT_GROUPS) do
 		local attrs = vim.deepcopy(default_attrs)

--- a/scripts/test_stage8_highlights.lua
+++ b/scripts/test_stage8_highlights.lua
@@ -79,6 +79,14 @@ assert_equals(
 	"palette selection highlight should remain defined"
 )
 
+-- Light background should use light palette colors
+local light_sep = get_highlight("GitflowSeparator", { link = false })
+assert_equals(
+	light_sep.fg,
+	tonumber(highlights.PALETTE_LIGHT.separator_fg:sub(2), 16),
+	"light background should apply light separator color"
+)
+
 highlights.setup({
 	GitflowAdded = { fg = "#00ff00", bold = true },
 })


### PR DESCRIPTION
Closes #178

## Summary
- **What changed**: `lua/gitflow/highlights.lua` now exports `PALETTE_DARK` and `PALETTE_LIGHT` with full color sets for both backgrounds. `setup()` reads `vim.o.background` to select the active palette before applying highlight groups.
- **Why**: The separator color `#3E4452` (dark gray) was invisible on light colorschemes. All other hardcoded accent colors (borders, headers, diff highlights) also needed light-friendly variants.
- **Key decisions/tradeoffs**:
  - `DEFAULT_GROUPS` is now built dynamically via `build_default_groups(palette)` — rebuilt on each `setup()` call rather than being a static table. This ensures palette-derived colors always match the current background.
  - Light palette colors are chosen for readability on light backgrounds (e.g., `#C8CCD4` light gray separator, `#0E7490` darker cyan accent, `#986801` darker gold for log hashes).
  - User `config.highlights` overrides still take full precedence over both palettes.

### Testing/Installing/Reviewing
- Run palette accent parity tests: `nvim --headless -u NONE -l scripts/test_palette_accent_parity.lua`
- Run highlight tests: `nvim --headless -u NONE -l scripts/test_stage8_highlights.lua`
- Full E2E suite: `for t in tests/e2e/*.lua; do nvim --headless -u tests/minimal_init.lua -l "$t"; done`
- Manual verification: set `vim.o.background = "light"` and open any Gitflow panel — separators, borders, and headers should be clearly visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)