### PR TITLE
Issue #252: Add closing confirmation to closing active PR review

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -188,7 +188,7 @@ Buffer-local bindings active in the review panel (`:Gitflow pr review`).
 | `<leader>t` | Toggle thread collapse/expand |
 | `<leader>b` | Back to PR view |
 | `r` | Refresh |
-| `q` | Close |
+| `q` | Close (confirms if pending comments exist) |
 
 ## Conflict Resolution
 

--- a/lua/gitflow/panels/review.lua
+++ b/lua/gitflow/panels/review.lua
@@ -192,7 +192,7 @@ local function ensure_window(cfg)
 	end, { buffer = bufnr, silent = true, nowait = true })
 
 	vim.keymap.set("n", "q", function()
-		M.close()
+		M.close_with_guard()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end
 
@@ -1205,6 +1205,24 @@ function M.back_to_pr()
 	else
 		pr_panel.open_view(number)
 	end
+end
+
+function M.close_with_guard()
+	local count = #M.state.pending_comments
+	if count > 0 then
+		local msg = (
+			"Are you sure you want to discard the review?"
+			.. " You have %d comment%s so far."
+		):format(count, count == 1 and "" or "s")
+		local confirmed = input.confirm(msg, {
+			choices = { "&Yes", "&No" },
+			default_choice = 2,
+		})
+		if not confirmed then
+			return
+		end
+	end
+	M.close()
 end
 
 function M.close()


### PR DESCRIPTION
Closes #252

## Summary

Pressing `q` in the review panel now checks for pending inline comments
before closing. If comments exist, a confirmation dialog asks the user
whether to discard the review. If the user cancels, the panel stays open
with all pending comments preserved. Reviews with no pending comments
close immediately as before.

### What changed
- `lua/gitflow/panels/review.lua`: Added `M.close_with_guard()` method
  that checks `#M.state.pending_comments > 0` and shows an
  `input.confirm()` dialog before calling `M.close()`. The `q` keymap
  now calls `close_with_guard()` instead of `close()`.
- `tests/e2e/pr_review_spec.lua`: 3 new E2E tests covering the guard
  (no pending → immediate close, pending + confirm → close, pending +
  cancel → stays open).
- `KEYBINDINGS.md`: Updated `q` description to note confirmation
  behavior when pending comments exist.

### Key decisions
- `M.close()` remains unconditional for programmatic callers (tests,
  `cleanup_panels`, etc.) — only the interactive `q` keymap goes
  through `close_with_guard()`.
- Default choice is `No` (safe default — avoids accidental discard).
- Uses the existing `input.confirm()` pattern already established by
  merge, delete, and reset confirmations.

## Test plan
- [x] E2E: `q with no pending comments closes immediately`
- [x] E2E: `q with pending comments shows confirmation` (user confirms)
- [x] E2E: `q with pending comments cancelled keeps panel` (user cancels)
- [x] All 10 E2E suites pass (222 tests, 0 failures)
- [x] Stage 5 review smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)