### PR TITLE
Issue #255: Title of issue/PR are not shown after selecting the issue/PR

### DIFF
--- a/lua/gitflow/panels/issues.lua
+++ b/lua/gitflow/panels/issues.lua
@@ -328,6 +328,7 @@ local function render_view(issue)
 		render_opts
 	)
 	local header_line_count = #lines
+	lines[#lines + 1] = ("Title: %s"):format(maybe_text(issue.title))
 	lines[#lines + 1] = ("State: %s %s"):format(view_icon, view_state)
 	lines[#lines + 1] = ("Author: %s"):format(issue.author and maybe_text(issue.author.login) or "-")
 	lines[#lines + 1] = ("Labels: %s"):format(join_label_names(issue))
@@ -379,7 +380,7 @@ local function render_view(issue)
 	end
 
 	local entry_highlights = {}
-	entry_highlights[header_line_count + 1] = issue_highlight_group(issue_state(issue))
+	entry_highlights[header_line_count + 2] = issue_highlight_group(issue_state(issue))
 
 	-- Mark section headers in detail view
 	for line_no, line in ipairs(lines) do
@@ -393,7 +394,7 @@ local function render_view(issue)
 	})
 
 	-- Colored labels in detail view
-	local labels_line_no = header_line_count + 3
+	local labels_line_no = header_line_count + 4
 	local labels_line = lines[labels_line_no] or ""
 	if labels_line:find("Labels:", 1, true) then
 		local issue_labels = issue.labels or {}

--- a/lua/gitflow/panels/prs.lua
+++ b/lua/gitflow/panels/prs.lua
@@ -361,6 +361,7 @@ local function render_view(pr)
 		render_opts
 	)
 	local header_line_count = #lines
+	lines[#lines + 1] = ("Title: %s"):format(maybe_text(pr.title))
 	lines[#lines + 1] = ("State: %s %s"):format(view_icon, view_state)
 	lines[#lines + 1] = ("Author: %s"):format(pr.author and maybe_text(pr.author.login) or "-")
 	lines[#lines + 1] = ("Refs: %s -> %s"):
@@ -425,7 +426,7 @@ local function render_view(pr)
 	end
 
 	local entry_highlights = {}
-	entry_highlights[header_line_count + 1] = pr_highlight_group(pr_state(pr))
+	entry_highlights[header_line_count + 2] = pr_highlight_group(pr_state(pr))
 
 	-- Mark section headers in detail view
 	for line_no, line in ipairs(lines) do

--- a/tests/e2e/detail_title_spec.lua
+++ b/tests/e2e/detail_title_spec.lua
@@ -1,0 +1,146 @@
+--- tests/e2e/detail_title_spec.lua
+---
+--- Verifies that issue and PR detail views display the title
+--- as a visible field before the Body section.
+
+local commands = require("gitflow.commands")
+local issues_panel = require("gitflow.panels.issues")
+local prs_panel = require("gitflow.panels.prs")
+local ui = require("gitflow.ui")
+local cfg = _G.TestConfig
+
+local function cleanup_panels()
+	for _, name in ipairs({
+		"issues", "prs", "status", "diff", "log",
+		"stash", "branch", "conflict", "labels",
+		"review", "palette",
+	}) do
+		local ok, mod = pcall(
+			require, "gitflow.panels." .. name
+		)
+		if ok and mod.close then
+			pcall(mod.close)
+		end
+	end
+end
+
+T.run_suite("detail_title_spec", {
+
+	-- ── Issue detail view ──────────────────────────
+
+	["issue view shows Title field"] = function()
+		cleanup_panels()
+		issues_panel.open_view(1, cfg)
+		T.drain_jobs(3000)
+
+		local bufnr = ui.buffer.get("issues")
+		T.assert_true(
+			bufnr ~= nil
+				and vim.api.nvim_buf_is_valid(bufnr),
+			"issues buffer should exist"
+		)
+
+		local lines = T.buf_lines(bufnr)
+		local title_line = T.find_line(
+			lines, "Title:"
+		)
+		T.assert_true(
+			title_line ~= nil,
+			"issue view should have a Title: line"
+		)
+
+		-- Title must contain the fixture title
+		T.assert_contains(
+			lines[title_line],
+			"Setup CI pipeline",
+			"Title line should show the issue title"
+		)
+
+		cleanup_panels()
+	end,
+
+	["issue view Title appears before Body"] = function()
+		cleanup_panels()
+		issues_panel.open_view(1, cfg)
+		T.drain_jobs(3000)
+
+		local bufnr = ui.buffer.get("issues")
+		T.assert_true(
+			bufnr ~= nil,
+			"issues buffer should exist"
+		)
+
+		local lines = T.buf_lines(bufnr)
+		local title_idx = T.find_line(lines, "Title:")
+		local body_idx = T.find_line(lines, "Body")
+		T.assert_true(
+			title_idx ~= nil and body_idx ~= nil,
+			"both Title and Body lines must exist"
+		)
+		T.assert_true(
+			title_idx < body_idx,
+			"Title line must appear before Body"
+		)
+
+		cleanup_panels()
+	end,
+
+	-- ── PR detail view ─────────────────────────────
+
+	["pr view shows Title field"] = function()
+		cleanup_panels()
+		prs_panel.open_view(42, cfg)
+		T.drain_jobs(3000)
+
+		local bufnr = ui.buffer.get("prs")
+		T.assert_true(
+			bufnr ~= nil
+				and vim.api.nvim_buf_is_valid(bufnr),
+			"prs buffer should exist"
+		)
+
+		local lines = T.buf_lines(bufnr)
+		local title_line = T.find_line(
+			lines, "Title:"
+		)
+		T.assert_true(
+			title_line ~= nil,
+			"PR view should have a Title: line"
+		)
+
+		-- Title must contain the fixture title
+		T.assert_contains(
+			lines[title_line],
+			"Add dark mode support",
+			"Title line should show the PR title"
+		)
+
+		cleanup_panels()
+	end,
+
+	["pr view Title appears before Body"] = function()
+		cleanup_panels()
+		prs_panel.open_view(42, cfg)
+		T.drain_jobs(3000)
+
+		local bufnr = ui.buffer.get("prs")
+		T.assert_true(
+			bufnr ~= nil,
+			"prs buffer should exist"
+		)
+
+		local lines = T.buf_lines(bufnr)
+		local title_idx = T.find_line(lines, "Title:")
+		local body_idx = T.find_line(lines, "Body")
+		T.assert_true(
+			title_idx ~= nil and body_idx ~= nil,
+			"both Title and Body lines must exist"
+		)
+		T.assert_true(
+			title_idx < body_idx,
+			"Title line must appear before Body"
+		)
+
+		cleanup_panels()
+	end,
+})


### PR DESCRIPTION
Closes #255

## Summary
- Added a `Title:` line in both issue and PR detail views (`render_view()`),
  rendered immediately after the panel header and before metadata fields
  (State, Author, Labels, etc.).
- Adjusted highlight offset for the State line (from `header_line_count + 1`
  to `+ 2`) and label-color offset in issue detail view (from
  `header_line_count + 3` to `+ 4`) so colored labels and state highlighting
  remain correctly positioned.
- Added E2E test suite (`tests/e2e/detail_title_spec.lua`) with 4 tests
  verifying title presence and ordering in both issue and PR detail views.

## Files Changed
- `lua/gitflow/panels/issues.lua` — `Title:` line + offset fixes
- `lua/gitflow/panels/prs.lua` — `Title:` line + offset fix
- `tests/e2e/detail_title_spec.lua` — new E2E test suite (4 tests)

## Test plan
- [x] `nvim --headless -u tests/minimal_init.lua -l tests/e2e/detail_title_spec.lua` — 4/4 pass
- [x] Full E2E suite (11 specs, 228 tests) — all pass
- [x] All stage tests (`scripts/test_stage*.lua`) — all pass
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)