### PR TITLE
Issue #251: Fix treesitter stacktrace in PR review panel

### DIFF
--- a/lua/gitflow/panels/diff.lua
+++ b/lua/gitflow/panels/diff.lua
@@ -129,14 +129,17 @@ local function ensure_window(cfg)
 		and M.state.bufnr or nil
 	if not bufnr then
 		bufnr = ui.buffer.create("diff", {
-			filetype = "diff",
+			filetype = "gitflow-diff",
 			lines = { "Loading diff..." },
 		})
 		M.state.bufnr = bufnr
 	end
 
 	vim.api.nvim_set_option_value(
-		"filetype", "diff", { buf = bufnr }
+		"filetype", "gitflow-diff", { buf = bufnr }
+	)
+	vim.api.nvim_set_option_value(
+		"syntax", "diff", { buf = bufnr }
 	)
 	vim.api.nvim_set_option_value(
 		"modifiable", false, { buf = bufnr }

--- a/lua/gitflow/panels/review.lua
+++ b/lua/gitflow/panels/review.lua
@@ -94,14 +94,21 @@ local function ensure_window(cfg)
 		and M.state.bufnr or nil
 	if not bufnr then
 		bufnr = ui.buffer.create("review", {
-			filetype = "diff",
+			filetype = "gitflow-diff",
 			lines = { "Loading review..." },
 		})
 		M.state.bufnr = bufnr
 	end
 
-	vim.api.nvim_set_option_value("filetype", "diff", { buf = bufnr })
-	vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+	vim.api.nvim_set_option_value(
+		"filetype", "gitflow-diff", { buf = bufnr }
+	)
+	vim.api.nvim_set_option_value(
+		"syntax", "diff", { buf = bufnr }
+	)
+	vim.api.nvim_set_option_value(
+		"modifiable", false, { buf = bufnr }
+	)
 
 	if M.state.winid and vim.api.nvim_win_is_valid(M.state.winid) then
 		vim.api.nvim_win_set_buf(M.state.winid, bufnr)

--- a/lua/gitflow/ui/conflict.lua
+++ b/lua/gitflow/ui/conflict.lua
@@ -555,8 +555,15 @@ end
 
 ---@param bufnr integer
 local function set_top_buffer_options(bufnr)
-	vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
-	vim.api.nvim_set_option_value("readonly", true, { buf = bufnr })
+	vim.api.nvim_set_option_value(
+		"syntax", "diff", { buf = bufnr }
+	)
+	vim.api.nvim_set_option_value(
+		"modifiable", false, { buf = bufnr }
+	)
+	vim.api.nvim_set_option_value(
+		"readonly", true, { buf = bufnr }
+	)
 end
 
 ---@param path string
@@ -564,18 +571,36 @@ end
 ---@param callbacks table
 local function open_layout(path, ctx, callbacks)
 	local name_key = sanitize(path)
-	local local_bufnr = ui.buffer.create(("conflict-local-%s"):format(name_key), {
-		filetype = "diff",
-		lines = with_fallback(ctx.local_lines, "(local version unavailable)"),
-	})
-	local base_bufnr = ui.buffer.create(("conflict-base-%s"):format(name_key), {
-		filetype = "diff",
-		lines = with_fallback(ctx.base_lines, "(base version unavailable)"),
-	})
-	local remote_bufnr = ui.buffer.create(("conflict-remote-%s"):format(name_key), {
-		filetype = "diff",
-		lines = with_fallback(ctx.remote_lines, "(remote version unavailable)"),
-	})
+	local local_bufnr = ui.buffer.create(
+		("conflict-local-%s"):format(name_key),
+		{
+			filetype = "gitflow-diff",
+			lines = with_fallback(
+				ctx.local_lines,
+				"(local version unavailable)"
+			),
+		}
+	)
+	local base_bufnr = ui.buffer.create(
+		("conflict-base-%s"):format(name_key),
+		{
+			filetype = "gitflow-diff",
+			lines = with_fallback(
+				ctx.base_lines,
+				"(base version unavailable)"
+			),
+		}
+	)
+	local remote_bufnr = ui.buffer.create(
+		("conflict-remote-%s"):format(name_key),
+		{
+			filetype = "gitflow-diff",
+			lines = with_fallback(
+				ctx.remote_lines,
+				"(remote version unavailable)"
+			),
+		}
+	)
 	local merged_bufnr = ui.buffer.create(("conflict-merged-%s"):format(name_key), {
 		filetype = "gitflowconflictmerge",
 		lines = ctx.merged_lines,

--- a/tests/e2e/open_ui_spec.lua
+++ b/tests/e2e/open_ui_spec.lua
@@ -231,6 +231,23 @@ T.run_suite("E2E: UI Initialization & Panel Open/Close", {
 			"diff buffer should exist after :Gitflow diff"
 		)
 
+		local ft = vim.api.nvim_get_option_value(
+			"filetype", { buf = bufnr }
+		)
+		T.assert_equals(
+			ft,
+			"gitflow-diff",
+			"diff buffer should use gitflow-diff filetype"
+		)
+
+		local has_ts = pcall(
+			vim.treesitter.get_parser, bufnr
+		)
+		T.assert_false(
+			has_ts,
+			"treesitter should not attach to diff buffer"
+		)
+
 		diff_panel.close()
 	end,
 


### PR DESCRIPTION
Closes #251

## Summary

- **What changed**: Review, diff, and conflict-view buffers now use
  `filetype = "gitflow-diff"` instead of `filetype = "diff"`, with
  `syntax = "diff"` set explicitly for Vim regex-based highlighting.
- **Why**: Setting `filetype = "diff"` caused Neovim to auto-attach a
  treesitter diff parser. When async re-renders replaced the entire
  buffer content (e.g. after adding an inline comment), the parser's
  stale parse tree held `end_row` values exceeding the new buffer's
  line count, crashing the decoration provider with
  `Invalid 'end_row': out of range`.
- **Key decisions**: Used a custom filetype (`gitflow-diff`) that
  treesitter has no parser for, rather than detaching/reattaching
  treesitter around each buffer update. This is simpler, more robust,
  and the plugin already applies its own extmark-based highlights.

### Files changed
- `lua/gitflow/panels/review.lua` — `filetype` → `gitflow-diff`, added `syntax = "diff"`
- `lua/gitflow/panels/diff.lua` — same pattern
- `lua/gitflow/ui/conflict.lua` — same pattern for LOCAL/BASE/REMOTE panes
- `tests/e2e/pr_review_spec.lua` — 2 new tests: filetype assertion + re-render treesitter guard
- `tests/e2e/open_ui_spec.lua` — filetype + treesitter assertions for diff panel

### Testing/Installing/Reviewing
- All 231 E2E tests pass (12 suites)
- All 16 stage tests pass
- All standalone test suites pass (cherry-pick, unified theme, palette accent parity)
- New tests verify `gitflow-diff` filetype and absence of treesitter parser on review/diff buffers

🤖 Generated with [Claude Code](https://claude.com/claude-code)