### PR TITLE
Issue #280: Implement git revert functionality

### DIFF
--- a/lua/gitflow/commands.lua
+++ b/lua/gitflow/commands.lua
@@ -22,6 +22,7 @@ local conflict_panel = require("gitflow.panels.conflict")
 local palette_panel = require("gitflow.panels.palette")
 local reset_panel = require("gitflow.panels.reset")
 local cherry_pick_panel = require("gitflow.panels.cherry_pick")
+local revert_panel = require("gitflow.panels.revert")
 local git_conflict = require("gitflow.git.conflict")
 local label_completion = require("gitflow.completion.labels")
 local assignee_completion = require("gitflow.completion.assignees")
@@ -1152,6 +1153,14 @@ local function register_builtin_subcommands(cfg)
 		end,
 	}
 
+	M.subcommands.revert = {
+		description = "Open git revert panel",
+		run = function()
+			revert_panel.open(cfg)
+			return "Revert panel opened"
+		end,
+	}
+
 	M.subcommands.stash = {
 		description = "Stash operations: list|push|pop|drop",
 		run = function(ctx)
@@ -2203,6 +2212,7 @@ function M.setup(cfg)
 	vim.keymap.set("n", "<Plug>(GitflowLabel)", "<Cmd>Gitflow label list<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowPalette)", "<Cmd>Gitflow palette<CR>", { silent = true })
 	vim.keymap.set("n", "<Plug>(GitflowReset)", "<Cmd>Gitflow reset<CR>", { silent = true })
+	vim.keymap.set("n", "<Plug>(GitflowRevert)", "<Cmd>Gitflow revert<CR>", { silent = true })
 	vim.keymap.set(
 		"n",
 		"<Plug>(GitflowCherryPick)",
@@ -2232,6 +2242,7 @@ function M.setup(cfg)
 		pr = "<Plug>(GitflowPr)",
 		label = "<Plug>(GitflowLabel)",
 		reset = "<Plug>(GitflowReset)",
+		revert = "<Plug>(GitflowRevert)",
 		cherry_pick = "<Plug>(GitflowCherryPick)",
 		palette = "<Plug>(GitflowPalette)",
 		conflict = "<Plug>(GitflowConflicts)",

--- a/lua/gitflow/config.lua
+++ b/lua/gitflow/config.lua
@@ -86,6 +86,7 @@ function M.defaults()
 			issue = "<leader>gi",
 			pr = "<leader>gr",
 			reset = "gR",
+			revert = "gV",
 			cherry_pick = "gC",
 			conflict = "<leader>gm",
 			palette = "<leader>go",

--- a/lua/gitflow/git/revert.lua
+++ b/lua/gitflow/git/revert.lua
@@ -1,0 +1,86 @@
+local git = require("gitflow.git")
+local git_log = require("gitflow.git.log")
+
+---@class GitflowRevertEntry
+---@field sha string
+---@field short_sha string
+---@field summary string
+
+local M = {}
+
+---@param result GitflowGitResult
+---@param action string
+---@return string
+local function error_from_result(result, action)
+	local output = git.output(result)
+	if output == "" then
+		return ("git %s failed"):format(action)
+	end
+	return ("git %s failed: %s"):format(action, output)
+end
+
+---List recent commits on the current branch.
+---Delegates to git log with a tab-separated full-SHA + summary format.
+---@param opts table|nil  { count?: integer }
+---@param cb fun(err: string|nil, entries: GitflowRevertEntry[]|nil)
+function M.list_commits(opts, cb)
+	local options = opts or {}
+	local count = tonumber(options.count) or 50
+	git_log.list({ count = count }, function(err, entries)
+		if err then
+			cb(err, nil)
+			return
+		end
+		cb(nil, entries)
+	end)
+end
+
+---Find the merge-base commit between HEAD and the default branch.
+---Tries main, then master, then origin/HEAD.
+---@param opts table|nil
+---@param cb fun(err: string|nil, sha: string|nil)
+function M.find_merge_base(opts, cb)
+	local candidates = { "main", "master", "origin/HEAD" }
+
+	local function try_next(index)
+		if index > #candidates then
+			cb(nil, nil)
+			return
+		end
+
+		local ref = candidates[index]
+		git.git({ "merge-base", "HEAD", ref }, opts or {}, function(result)
+			if result.code == 0 then
+				local sha = vim.trim(result.stdout or "")
+				if sha ~= "" then
+					cb(nil, sha)
+					return
+				end
+			end
+			try_next(index + 1)
+		end)
+	end
+
+	try_next(1)
+end
+
+---Execute git revert for a single commit.
+---@param sha string  target commit SHA
+---@param cb fun(err: string|nil, result: GitflowGitResult)
+function M.revert(sha, cb)
+	if not sha or sha == "" then
+		error(
+			"gitflow revert error: revert(sha, cb) requires a SHA", 2
+		)
+	end
+
+	git.git({ "revert", "--no-edit", sha }, {}, function(result)
+		if result.code ~= 0 then
+			cb(error_from_result(result, "revert"), result)
+			return
+		end
+		cb(nil, result)
+	end)
+end
+
+return M

--- a/lua/gitflow/highlights.lua
+++ b/lua/gitflow/highlights.lua
@@ -100,6 +100,8 @@ local function build_default_groups(palette)
 		GitflowPaletteBackdrop = { bg = palette.backdrop_bg },
 		-- Reset
 		GitflowResetMergeBase = { link = "WarningMsg" },
+		-- Revert
+		GitflowRevertMergeBase = { link = "WarningMsg" },
 		-- Cherry Pick
 		GitflowCherryPickBranch = { fg = palette.stash_ref, bold = true },
 		GitflowCherryPickHash = { fg = palette.log_hash, bold = true },

--- a/lua/gitflow/icons.lua
+++ b/lua/gitflow/icons.lua
@@ -101,6 +101,7 @@ local registry = {
 		pr = { nerd = NF.pr_open, ascii = "!" },
 		review = { nerd = NF.review_commented, ascii = "R" },
 		reset = { nerd = NF.commit, ascii = "R" },
+		revert = { nerd = NF.commit, ascii = "V" },
 		palette = { nerd = NF.palette_ui, ascii = ">" },
 		help = { nerd = NF.palette_ui, ascii = "?" },
 		open = { nerd = NF.palette_ui, ascii = ">" },

--- a/lua/gitflow/panels/revert.lua
+++ b/lua/gitflow/panels/revert.lua
@@ -1,0 +1,389 @@
+local ui = require("gitflow.ui")
+local utils = require("gitflow.utils")
+local git = require("gitflow.git")
+local git_revert = require("gitflow.git.revert")
+local git_branch = require("gitflow.git.branch")
+local git_conflict = require("gitflow.git.conflict")
+local icons = require("gitflow.icons")
+local ui_render = require("gitflow.ui.render")
+local status_panel = require("gitflow.panels.status")
+
+---@class GitflowRevertPanelState
+---@field bufnr integer|nil
+---@field winid integer|nil
+---@field line_entries table<integer, GitflowRevertEntry>
+---@field merge_base_sha string|nil
+---@field cfg GitflowConfig|nil
+
+local M = {}
+local REVERT_FLOAT_TITLE = "Gitflow Revert"
+local REVERT_FLOAT_FOOTER =
+	"<CR> revert  1-9 by position  r refresh  q close"
+local REVERT_HIGHLIGHT_NS =
+	vim.api.nvim_create_namespace("gitflow_revert_hl")
+
+---@type GitflowRevertPanelState
+M.state = {
+	bufnr = nil,
+	winid = nil,
+	line_entries = {},
+	merge_base_sha = nil,
+	cfg = nil,
+}
+
+local function refresh_status_panel_if_open()
+	if status_panel.is_open() then
+		status_panel.refresh()
+	end
+end
+
+local function emit_post_operation()
+	vim.api.nvim_exec_autocmds(
+		"User", { pattern = "GitflowPostOperation" }
+	)
+end
+
+---@param cfg GitflowConfig
+local function ensure_window(cfg)
+	local bufnr = M.state.bufnr
+		and vim.api.nvim_buf_is_valid(M.state.bufnr)
+		and M.state.bufnr or nil
+	if not bufnr then
+		bufnr = ui.buffer.create("revert", {
+			filetype = "gitflowrevert",
+			lines = { "Loading commits..." },
+		})
+		M.state.bufnr = bufnr
+	end
+
+	vim.api.nvim_set_option_value(
+		"modifiable", false, { buf = bufnr }
+	)
+
+	if M.state.winid
+		and vim.api.nvim_win_is_valid(M.state.winid)
+	then
+		vim.api.nvim_win_set_buf(M.state.winid, bufnr)
+		return
+	end
+
+	if cfg.ui.default_layout == "float" then
+		M.state.winid = ui.window.open_float({
+			name = "revert",
+			bufnr = bufnr,
+			width = cfg.ui.float.width,
+			height = cfg.ui.float.height,
+			border = cfg.ui.float.border,
+			title = REVERT_FLOAT_TITLE,
+			title_pos = cfg.ui.float.title_pos,
+			footer = cfg.ui.float.footer
+				and REVERT_FLOAT_FOOTER or nil,
+			footer_pos = cfg.ui.float.footer_pos,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	else
+		M.state.winid = ui.window.open_split({
+			name = "revert",
+			bufnr = bufnr,
+			orientation = cfg.ui.split.orientation,
+			size = cfg.ui.split.size,
+			on_close = function()
+				M.state.winid = nil
+			end,
+		})
+	end
+
+	vim.keymap.set("n", "<CR>", function()
+		M.select_under_cursor()
+	end, { buffer = bufnr, silent = true })
+
+	for i = 1, 9 do
+		vim.keymap.set("n", tostring(i), function()
+			M.select_by_position(i)
+		end, { buffer = bufnr, silent = true, nowait = true })
+	end
+
+	vim.keymap.set("n", "r", function()
+		M.refresh()
+	end, { buffer = bufnr, silent = true, nowait = true })
+
+	vim.keymap.set("n", "q", function()
+		M.close()
+	end, { buffer = bufnr, silent = true, nowait = true })
+end
+
+---@param entries GitflowRevertEntry[]
+---@param merge_base_sha string|nil
+---@param current_branch string
+local function render(entries, merge_base_sha, current_branch)
+	local render_opts = {
+		bufnr = M.state.bufnr,
+		winid = M.state.winid,
+	}
+	local lines = ui_render.panel_header(
+		"Gitflow Revert", render_opts
+	)
+	local line_entries = {}
+	local entry_highlights = {}
+
+	if #entries == 0 then
+		lines[#lines + 1] = ui_render.empty("no commits found")
+	else
+		for idx, entry in ipairs(entries) do
+			local commit_icon = icons.get("git_state", "commit")
+			local position_marker = ""
+			if idx <= 9 then
+				position_marker = ("[%d] "):format(idx)
+			end
+			lines[#lines + 1] = ui_render.entry(
+				("%s%s %s %s"):format(
+					position_marker,
+					commit_icon,
+					entry.short_sha,
+					entry.summary
+				)
+			)
+			line_entries[#lines] = entry
+
+			if merge_base_sha
+				and entry.sha:sub(1, #merge_base_sha)
+					== merge_base_sha
+			then
+				entry_highlights[#lines] =
+					"GitflowRevertMergeBase"
+			elseif merge_base_sha
+				and merge_base_sha:sub(1, #entry.sha)
+					== entry.sha
+			then
+				entry_highlights[#lines] =
+					"GitflowRevertMergeBase"
+			end
+		end
+	end
+
+	local footer_lines = ui_render.panel_footer(
+		current_branch, nil, render_opts
+	)
+	for _, line in ipairs(footer_lines) do
+		lines[#lines + 1] = line
+	end
+
+	ui.buffer.update("revert", lines)
+	M.state.line_entries = line_entries
+	M.state.merge_base_sha = merge_base_sha
+
+	local bufnr = M.state.bufnr
+	if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+		return
+	end
+
+	ui_render.apply_panel_highlights(
+		bufnr, REVERT_HIGHLIGHT_NS, lines, {
+			footer_line = #lines,
+			entry_highlights = entry_highlights,
+		}
+	)
+end
+
+---@return GitflowRevertEntry|nil
+local function entry_under_cursor()
+	if not M.state.bufnr
+		or vim.api.nvim_get_current_buf() ~= M.state.bufnr
+	then
+		return nil
+	end
+	local line = vim.api.nvim_win_get_cursor(0)[1]
+	return M.state.line_entries[line]
+end
+
+---Find the Nth entry (1-indexed) from the line_entries map.
+---@param position integer
+---@return GitflowRevertEntry|nil
+local function entry_by_position(position)
+	local sorted_lines = {}
+	for line_no, _ in pairs(M.state.line_entries) do
+		sorted_lines[#sorted_lines + 1] = line_no
+	end
+	table.sort(sorted_lines)
+
+	if position < 1 or position > #sorted_lines then
+		return nil
+	end
+	return M.state.line_entries[sorted_lines[position]]
+end
+
+---Confirm and execute git revert for a commit.
+---@param entry GitflowRevertEntry
+local function execute_revert(entry)
+	local cfg = M.state.cfg
+	if not cfg then
+		return
+	end
+
+	local confirmed = ui.input.confirm(
+		("Revert commit %s %s?\n\n"
+			.. "This will create a new commit that undoes"
+			.. " the changes."):format(
+			entry.short_sha,
+			entry.summary
+		),
+		{
+			choices = { "&Revert", "&Cancel" },
+			default_choice = 1,
+		}
+	)
+	if not confirmed then
+		return
+	end
+
+	git_revert.revert(entry.sha, function(err, result)
+		if err then
+			local output = git.output(result) or err
+			local parsed =
+				git_conflict.parse_conflicted_paths_from_output(
+					output
+				)
+			if #parsed > 0 then
+				utils.notify(
+					("Revert has conflicts:\n%s"):format(
+						table.concat(parsed, "\n")
+					),
+					vim.log.levels.ERROR
+				)
+				local conflict_panel =
+					require("gitflow.panels.conflict")
+				refresh_status_panel_if_open()
+				conflict_panel.open(cfg)
+			else
+				git_conflict.list(
+					{},
+					function(c_err, conflicted)
+						if c_err
+							or #(conflicted or {}) == 0
+						then
+							utils.notify(
+								err,
+								vim.log.levels.ERROR
+							)
+							return
+						end
+						utils.notify(
+							("Revert has"
+								.. " conflicts:\n%s"):format(
+								table.concat(
+									conflicted, "\n"
+								)
+							),
+							vim.log.levels.ERROR
+						)
+						local cp =
+							require(
+								"gitflow.panels.conflict"
+							)
+						refresh_status_panel_if_open()
+						cp.open(cfg)
+					end
+				)
+			end
+			return
+		end
+
+		local output = git.output(result)
+		if output == "" then
+			output = ("Reverted %s"):format(entry.short_sha)
+		end
+		utils.notify(output, vim.log.levels.INFO)
+		M.close()
+		refresh_status_panel_if_open()
+		emit_post_operation()
+	end)
+end
+
+---@param cfg GitflowConfig
+function M.open(cfg)
+	M.state.cfg = cfg
+	ensure_window(cfg)
+	M.refresh()
+end
+
+function M.refresh()
+	local cfg = M.state.cfg
+	if not cfg then
+		return
+	end
+
+	git_branch.current({}, function(_, branch)
+		git_revert.list_commits({
+			count = cfg.git.log.count,
+		}, function(log_err, entries)
+			if log_err then
+				utils.notify(log_err, vim.log.levels.ERROR)
+				return
+			end
+
+			git_revert.find_merge_base(
+				{},
+				function(_, merge_base)
+					render(
+						entries or {},
+						merge_base,
+						branch or "(unknown)"
+					)
+				end
+			)
+		end)
+	end)
+end
+
+function M.select_under_cursor()
+	local entry = entry_under_cursor()
+	if not entry then
+		utils.notify(
+			"No commit selected", vim.log.levels.WARN
+		)
+		return
+	end
+	execute_revert(entry)
+end
+
+---@param position integer
+function M.select_by_position(position)
+	local entry = entry_by_position(position)
+	if not entry then
+		utils.notify(
+			("No commit at position %d"):format(position),
+			vim.log.levels.WARN
+		)
+		return
+	end
+	execute_revert(entry)
+end
+
+function M.close()
+	if M.state.winid then
+		ui.window.close(M.state.winid)
+	else
+		ui.window.close("revert")
+	end
+
+	if M.state.bufnr then
+		ui.buffer.teardown(M.state.bufnr)
+	else
+		ui.buffer.teardown("revert")
+	end
+
+	M.state.bufnr = nil
+	M.state.winid = nil
+	M.state.line_entries = {}
+	M.state.merge_base_sha = nil
+end
+
+---@return boolean
+function M.is_open()
+	return M.state.bufnr ~= nil
+		and vim.api.nvim_buf_is_valid(M.state.bufnr)
+end
+
+return M

--- a/scripts/test_revert.lua
+++ b/scripts/test_revert.lua
@@ -1,0 +1,613 @@
+local script_path = debug.getinfo(1, "S").source:sub(2)
+local project_root = vim.fn.fnamemodify(script_path, ":p:h:h")
+vim.opt.runtimepath:append(project_root)
+
+local function assert_true(condition, message)
+	if not condition then
+		error(message, 2)
+	end
+end
+
+local function assert_equals(actual, expected, message)
+	if actual ~= expected then
+		error(
+			("%s (expected=%s, actual=%s)"):format(
+				message, vim.inspect(expected), vim.inspect(actual)
+			),
+			2
+		)
+	end
+end
+
+local function contains(list, value)
+	for _, item in ipairs(list) do
+		if item == value then
+			return true
+		end
+	end
+	return false
+end
+
+local unpack_fn = table.unpack or unpack
+
+local function wait_async(start, timeout_ms)
+	local done = false
+	local result = nil
+
+	start(function(...)
+		result = { ... }
+		done = true
+	end)
+
+	local ok = vim.wait(timeout_ms or 5000, function()
+		return done
+	end, 10)
+	assert_true(ok, "async callback timed out")
+	return unpack_fn(result)
+end
+
+local function run_git(repo_dir, args, should_succeed)
+	local cmd = { "git" }
+	vim.list_extend(cmd, args)
+	local output = ""
+	local code = 1
+
+	if vim.system then
+		local result = vim.system(cmd, { cwd = repo_dir, text = true }):wait()
+		output = (result.stdout or "") .. (result.stderr or "")
+		code = result.code or 1
+	else
+		local previous = vim.fn.getcwd()
+		vim.fn.chdir(repo_dir)
+		output = vim.fn.system(cmd)
+		code = vim.v.shell_error
+		vim.fn.chdir(previous)
+	end
+	if should_succeed == nil then
+		should_succeed = true
+	end
+	if should_succeed and code ~= 0 then
+		error(
+			("git command failed (%s): %s"):format(
+				table.concat(cmd, " "), output
+			),
+			2
+		)
+	end
+	return output, code
+end
+
+local function write_file(path, lines)
+	vim.fn.writefile(lines, path)
+end
+
+local function assert_mapping(lhs, expected_rhs, message)
+	local mapping = vim.fn.maparg(lhs, "n", false, true)
+	assert_true(
+		type(mapping) == "table" and mapping.rhs == expected_rhs, message
+	)
+end
+
+local passed = 0
+local failed = 0
+local test_name = ""
+
+local function test(name, fn)
+	test_name = name
+	local ok, err = pcall(fn)
+	if ok then
+		passed = passed + 1
+		print(("  PASS: %s"):format(name))
+	else
+		failed = failed + 1
+		print(("  FAIL: %s\n        %s"):format(name, tostring(err)))
+	end
+end
+
+print("=== Gitflow Revert Panel Tests ===")
+
+-- Set up a temp repo with multiple commits and a main branch
+local repo_dir = vim.fn.tempname()
+assert_equals(
+	vim.fn.mkdir(repo_dir, "p"), 1,
+	"temp repo directory should be created"
+)
+
+run_git(repo_dir, { "init", "-b", "main" })
+run_git(repo_dir, { "config", "user.email", "revert@example.com" })
+run_git(repo_dir, { "config", "user.name", "Revert Tester" })
+
+write_file(repo_dir .. "/file.txt", { "line1" })
+run_git(repo_dir, { "add", "file.txt" })
+run_git(repo_dir, { "commit", "-m", "initial commit" })
+
+write_file(repo_dir .. "/file.txt", { "line1", "line2" })
+run_git(repo_dir, { "add", "file.txt" })
+run_git(repo_dir, { "commit", "-m", "second commit" })
+
+-- Create a feature branch with additional commits
+run_git(repo_dir, { "checkout", "-b", "feature" })
+
+write_file(repo_dir .. "/file.txt", { "line1", "line2", "line3" })
+run_git(repo_dir, { "add", "file.txt" })
+run_git(repo_dir, { "commit", "-m", "feature commit 1" })
+
+write_file(repo_dir .. "/file.txt", { "line1", "line2", "line3", "line4" })
+run_git(repo_dir, { "add", "file.txt" })
+run_git(repo_dir, { "commit", "-m", "feature commit 2" })
+
+local original_cwd = vim.fn.getcwd()
+vim.fn.chdir(repo_dir)
+
+local gitflow = require("gitflow")
+local cfg = gitflow.setup({
+	ui = {
+		default_layout = "split",
+		split = {
+			orientation = "vertical",
+			size = 45,
+		},
+	},
+	git = {
+		log = {
+			count = 25,
+			format = "%h %s",
+		},
+	},
+})
+
+-- ─── Module loading tests ───
+
+test("git/revert module loads successfully", function()
+	local git_revert = require("gitflow.git.revert")
+	assert_true(type(git_revert) == "table", "module should be a table")
+	assert_true(
+		type(git_revert.list_commits) == "function",
+		"list_commits should be a function"
+	)
+	assert_true(
+		type(git_revert.find_merge_base) == "function",
+		"find_merge_base should be a function"
+	)
+	assert_true(
+		type(git_revert.revert) == "function",
+		"revert should be a function"
+	)
+end)
+
+test("panels/revert module loads successfully", function()
+	local revert_panel = require("gitflow.panels.revert")
+	assert_true(type(revert_panel) == "table", "module should be a table")
+	assert_true(
+		type(revert_panel.open) == "function",
+		"open should be a function"
+	)
+	assert_true(
+		type(revert_panel.close) == "function",
+		"close should be a function"
+	)
+	assert_true(
+		type(revert_panel.refresh) == "function",
+		"refresh should be a function"
+	)
+	assert_true(
+		type(revert_panel.is_open) == "function",
+		"is_open should be a function"
+	)
+	assert_true(
+		type(revert_panel.select_under_cursor) == "function",
+		"select_under_cursor should be a function"
+	)
+	assert_true(
+		type(revert_panel.select_by_position) == "function",
+		"select_by_position should be a function"
+	)
+end)
+
+-- ─── Subcommand registration tests ───
+
+test("revert subcommand is registered", function()
+	local commands = require("gitflow.commands")
+	local all = commands.complete("")
+	assert_true(
+		contains(all, "revert"),
+		"revert should appear in subcommand completions"
+	)
+end)
+
+test("revert subcommand has correct description", function()
+	local commands = require("gitflow.commands")
+	assert_true(
+		commands.subcommands.revert ~= nil,
+		"revert subcommand should exist"
+	)
+	assert_equals(
+		commands.subcommands.revert.description,
+		"Open git revert panel",
+		"revert subcommand description should match"
+	)
+end)
+
+-- ─── Keybinding tests ───
+
+test("default revert keybinding is gV", function()
+	assert_equals(
+		cfg.keybindings.revert, "gV",
+		"default revert keybinding should be gV"
+	)
+end)
+
+test("GitflowRevert plug mapping is registered", function()
+	assert_mapping(
+		"<Plug>(GitflowRevert)",
+		"<Cmd>Gitflow revert<CR>",
+		"revert plug keymap should be registered"
+	)
+end)
+
+test("default revert keymap maps to plug", function()
+	assert_mapping(
+		cfg.keybindings.revert,
+		"<Plug>(GitflowRevert)",
+		"gV should map to <Plug>(GitflowRevert)"
+	)
+end)
+
+-- ─── Highlight group tests ───
+
+test("GitflowRevertMergeBase highlight group is defined", function()
+	local highlights = require("gitflow.highlights")
+	assert_true(
+		highlights.DEFAULT_GROUPS.GitflowRevertMergeBase ~= nil,
+		"GitflowRevertMergeBase should be in DEFAULT_GROUPS"
+	)
+	assert_equals(
+		highlights.DEFAULT_GROUPS.GitflowRevertMergeBase.link,
+		"WarningMsg",
+		"GitflowRevertMergeBase should link to WarningMsg"
+	)
+end)
+
+test("GitflowRevertMergeBase highlight is applied after setup", function()
+	local hl = vim.api.nvim_get_hl(0, { name = "GitflowRevertMergeBase" })
+	assert_true(
+		hl ~= nil and (hl.link ~= nil or next(hl) ~= nil),
+		"GitflowRevertMergeBase highlight should be applied"
+	)
+end)
+
+-- ─── Icon tests ───
+
+test("revert icon is registered in palette category", function()
+	local icons_mod = require("gitflow.icons")
+	local icon = icons_mod.get("palette", "revert")
+	assert_true(
+		icon ~= nil and icon ~= "",
+		"revert icon should be available in palette category"
+	)
+end)
+
+-- ─── Git operation tests ───
+
+test("list_commits returns commit entries", function()
+	local git_revert = require("gitflow.git.revert")
+	local err, entries = wait_async(function(done)
+		git_revert.list_commits({ count = 10 }, function(e, ents)
+			done(e, ents)
+		end)
+	end)
+
+	assert_true(err == nil, "list_commits should not error")
+	assert_true(
+		type(entries) == "table" and #entries > 0,
+		"should return at least one entry"
+	)
+	assert_true(
+		entries[1].sha ~= nil and entries[1].sha ~= "",
+		"entry should have a sha"
+	)
+	assert_true(
+		entries[1].short_sha ~= nil and entries[1].short_sha ~= "",
+		"entry should have a short_sha"
+	)
+	assert_true(
+		entries[1].summary ~= nil and entries[1].summary ~= "",
+		"entry should have a summary"
+	)
+end)
+
+test("find_merge_base returns SHA on diverged branch", function()
+	local git_revert = require("gitflow.git.revert")
+	local err, sha = wait_async(function(done)
+		git_revert.find_merge_base({}, function(e, s)
+			done(e, s)
+		end)
+	end)
+
+	assert_true(err == nil, "find_merge_base should not error")
+	assert_true(
+		type(sha) == "string" and #sha > 0,
+		"merge-base SHA should be a non-empty string"
+	)
+end)
+
+-- ─── Panel lifecycle tests ───
+
+test("revert panel opens and shows commits", function()
+	local revert_panel = require("gitflow.panels.revert")
+	revert_panel.open(cfg)
+
+	vim.wait(2000, function()
+		if not revert_panel.state.bufnr then
+			return false
+		end
+		if not vim.api.nvim_buf_is_valid(revert_panel.state.bufnr) then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(
+			revert_panel.state.bufnr, 0, -1, false
+		)
+		return #lines > 1 and not lines[1]:find("Loading", 1, true)
+	end, 50)
+
+	assert_true(revert_panel.is_open(), "revert panel should be open")
+	assert_true(
+		revert_panel.state.bufnr ~= nil,
+		"bufnr should be set"
+	)
+	assert_true(
+		revert_panel.state.winid ~= nil,
+		"winid should be set"
+	)
+
+	local lines = vim.api.nvim_buf_get_lines(
+		revert_panel.state.bufnr, 0, -1, false
+	)
+	assert_true(#lines > 2, "should have rendered commit lines")
+
+	-- Check that at least one line has a commit entry marker
+	local has_entry = false
+	for _, line in ipairs(lines) do
+		if line:find("feature commit", 1, true) then
+			has_entry = true
+			break
+		end
+	end
+	assert_true(has_entry, "should contain a commit summary line")
+
+	revert_panel.close()
+end)
+
+test("revert panel keymaps are set on buffer", function()
+	local revert_panel = require("gitflow.panels.revert")
+	revert_panel.open(cfg)
+
+	vim.wait(1000, function()
+		return revert_panel.state.bufnr ~= nil
+			and vim.api.nvim_buf_is_valid(revert_panel.state.bufnr)
+	end, 50)
+
+	local bufnr = revert_panel.state.bufnr
+	assert_true(bufnr ~= nil, "bufnr should exist")
+
+	local keymaps = vim.api.nvim_buf_get_keymap(bufnr, "n")
+	local found_keys = {}
+	for _, km in ipairs(keymaps) do
+		found_keys[km.lhs] = true
+	end
+
+	assert_true(found_keys["<CR>"] ~= nil, "CR keymap should be set")
+	assert_true(found_keys["r"] ~= nil, "r keymap should be set")
+	assert_true(found_keys["q"] ~= nil, "q keymap should be set")
+	assert_true(found_keys["1"] ~= nil, "1 keymap should be set")
+	assert_true(found_keys["9"] ~= nil, "9 keymap should be set")
+
+	revert_panel.close()
+end)
+
+test("revert panel close cleans up state", function()
+	local revert_panel = require("gitflow.panels.revert")
+	revert_panel.open(cfg)
+
+	vim.wait(500, function()
+		return revert_panel.state.bufnr ~= nil
+	end, 50)
+
+	revert_panel.close()
+
+	assert_true(
+		revert_panel.state.bufnr == nil,
+		"bufnr should be nil after close"
+	)
+	assert_true(
+		revert_panel.state.winid == nil,
+		"winid should be nil after close"
+	)
+	assert_true(
+		not revert_panel.is_open(),
+		"is_open should return false after close"
+	)
+end)
+
+test("merge-base commit is highlighted", function()
+	local revert_panel = require("gitflow.panels.revert")
+	revert_panel.open(cfg)
+
+	vim.wait(2000, function()
+		if not revert_panel.state.bufnr then
+			return false
+		end
+		if not vim.api.nvim_buf_is_valid(revert_panel.state.bufnr) then
+			return false
+		end
+		return revert_panel.state.merge_base_sha ~= nil
+	end, 50)
+
+	assert_true(
+		revert_panel.state.merge_base_sha ~= nil,
+		"merge_base_sha should be set after render"
+	)
+
+	-- Check that highlight extmarks were applied
+	local bufnr = revert_panel.state.bufnr
+	local ns = vim.api.nvim_create_namespace("gitflow_revert_hl")
+	local extmarks = vim.api.nvim_buf_get_extmarks(
+		bufnr, ns, 0, -1, { details = true }
+	)
+	assert_true(
+		#extmarks > 0,
+		"should have highlight extmarks applied"
+	)
+
+	-- Look for the merge-base highlight specifically
+	local has_merge_base_hl = false
+	for _, mark in ipairs(extmarks) do
+		local details = mark[4]
+		if details and details.hl_group == "GitflowRevertMergeBase" then
+			has_merge_base_hl = true
+			break
+		end
+	end
+	assert_true(
+		has_merge_base_hl,
+		"GitflowRevertMergeBase highlight should be applied to"
+			.. " the merge-base line"
+	)
+
+	revert_panel.close()
+end)
+
+test("position numbers are rendered for first 9 commits", function()
+	local revert_panel = require("gitflow.panels.revert")
+	revert_panel.open(cfg)
+
+	vim.wait(2000, function()
+		if not revert_panel.state.bufnr then
+			return false
+		end
+		if not vim.api.nvim_buf_is_valid(revert_panel.state.bufnr) then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(
+			revert_panel.state.bufnr, 0, -1, false
+		)
+		return #lines > 1 and not lines[1]:find("Loading", 1, true)
+	end, 50)
+
+	local lines = vim.api.nvim_buf_get_lines(
+		revert_panel.state.bufnr, 0, -1, false
+	)
+
+	local has_numbered = false
+	for _, line in ipairs(lines) do
+		if line:find("%[1%]", 1, false) then
+			has_numbered = true
+			break
+		end
+	end
+	assert_true(
+		has_numbered,
+		"first commit should have [1] position marker"
+	)
+
+	revert_panel.close()
+end)
+
+test("line_entries map is populated after render", function()
+	local revert_panel = require("gitflow.panels.revert")
+	revert_panel.open(cfg)
+
+	vim.wait(2000, function()
+		if not revert_panel.state.bufnr then
+			return false
+		end
+		local lines = vim.api.nvim_buf_get_lines(
+			revert_panel.state.bufnr, 0, -1, false
+		)
+		return #lines > 1 and not lines[1]:find("Loading", 1, true)
+	end, 50)
+
+	local entry_count = 0
+	for _ in pairs(revert_panel.state.line_entries) do
+		entry_count = entry_count + 1
+	end
+	assert_true(
+		entry_count >= 4,
+		"should have at least 4 commit entries in line_entries"
+	)
+
+	revert_panel.close()
+end)
+
+test("git revert executes successfully", function()
+	-- Get current HEAD
+	local head_sha = vim.trim(
+		run_git(repo_dir, { "rev-parse", "HEAD" })
+	)
+
+	local git_revert = require("gitflow.git.revert")
+	local err = wait_async(function(done)
+		git_revert.revert(head_sha, function(e, _)
+			done(e)
+		end)
+	end)
+
+	assert_true(err == nil, "revert should not error")
+
+	-- Verify a new commit was created (HEAD moved forward)
+	local new_head = vim.trim(
+		run_git(repo_dir, { "rev-parse", "HEAD" })
+	)
+	assert_true(
+		new_head ~= head_sha,
+		"HEAD should have moved to a new revert commit"
+	)
+
+	-- Verify the revert commit message
+	local log_msg = vim.trim(
+		run_git(repo_dir, { "log", "-1", "--format=%s" })
+	)
+	assert_true(
+		log_msg:find("Revert", 1, true) ~= nil,
+		"revert commit message should contain 'Revert'"
+	)
+
+	-- Restore original HEAD for subsequent tests
+	run_git(repo_dir, { "reset", "--hard", head_sha })
+end)
+
+test("config validation accepts revert keybinding", function()
+	local config = require("gitflow.config")
+	local test_cfg = config.defaults()
+	test_cfg.keybindings.revert = "gV"
+	local ok = pcall(config.validate, test_cfg)
+	assert_true(ok, "config validation should pass with revert keybinding")
+end)
+
+test("dispatch revert subcommand returns expected message", function()
+	local commands = require("gitflow.commands")
+	local result = commands.dispatch({ "revert" }, cfg)
+	-- The panel opens asynchronously, but dispatch returns a message
+	assert_true(
+		type(result) == "string",
+		"dispatch should return a string"
+	)
+
+	-- Clean up the panel
+	local revert_panel = require("gitflow.panels.revert")
+	vim.wait(500, function()
+		return revert_panel.state.bufnr ~= nil
+	end, 50)
+	revert_panel.close()
+end)
+
+-- ─── Cleanup ───
+
+vim.fn.chdir(original_cwd)
+vim.fn.delete(repo_dir, "rf")
+
+print(("=== Results: %d passed, %d failed ==="):format(passed, failed))
+if failed > 0 then
+	vim.cmd("cquit! 1")
+end
+vim.cmd("qall!")


### PR DESCRIPTION
Closes #280

## Summary
- **New `git/revert.lua`** — git operations layer with `list_commits`, `find_merge_base`, and `revert` (uses `--no-edit` for clean automated commits)
- **New `panels/revert.lua`** — full UI panel modelled on the reset panel, with commit list, position markers, merge-base highlighting, confirmation prompt, and conflict detection that auto-opens the conflict panel
- **Wiring** — `revert` subcommand in `commands.lua`, `<Plug>(GitflowRevert)` mapping, `gV` default keybinding in `config.lua`, palette icon in `icons.lua`, `GitflowRevertMergeBase` highlight in `highlights.lua`
- **21-test suite** in `scripts/test_revert.lua` covering module loading, subcommand registration, keybinding wiring, highlights, icons, git operations, and panel lifecycle

## Key decisions
- Keybinding `gV` chosen to avoid conflicts with existing `gR` (reset) and `gC` (cherry-pick)
- Uses `git revert --no-edit` to auto-generate the standard revert commit message
- Conflict handling follows the cherry-pick pattern: parse output for conflicted paths → open conflict panel

## Test plan
- [x] `nvim --headless -u NONE -l scripts/test_revert.lua` — 21/21 pass
- [x] `nvim --headless -u NONE -l scripts/test_reset.lua` — 22/22 pass (no regression)
- [x] Stage 1 + 2 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)