### PR TITLE
Issue #296: We should be able to see inline review comments when reviewing a PR

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -186,6 +186,7 @@ Buffer-local bindings active in the review panel (`:Gitflow pr review`).
 | `S` | Submit pending review |
 | `R` | Reply to comment thread |
 | `<leader>t` | Toggle thread collapse/expand |
+| `<leader>i` | Toggle inline comment bodies on diff lines |
 | `<leader>b` | Back to PR view |
 | `r` | Refresh |
 | `q` | Close (confirms if pending comments exist) |

--- a/scripts/test_stage5.lua
+++ b/scripts/test_stage5.lua
@@ -674,6 +674,109 @@ if cur_review_buf then
 	end
 end
 
+-- toggle_inline_comments test: verify <leader>i keymap and behavior
+assert_keymaps(
+	buffer.get("review"),
+	{ leader .. "i" }
+)
+
+-- Default state: show_inline_comments should be false
+assert_equals(
+	review_panel.state.show_inline_comments, false,
+	"show_inline_comments should default to false"
+)
+
+-- Find the diff line where comments are attached (line 11 in commands.lua)
+local inline_buf = buffer.get("review")
+assert_true(
+	inline_buf ~= nil,
+	"review buffer should exist for inline toggle test"
+)
+local ns_comments = vim.api.nvim_get_namespaces()
+	.gitflow_review_comments
+assert_true(
+	ns_comments ~= nil,
+	"gitflow_review_comments namespace should exist"
+)
+
+-- Before toggle: extmarks should NOT have virt_lines
+local pre_marks = vim.api.nvim_buf_get_extmarks(
+	inline_buf, ns_comments, 0, -1, { details = true }
+)
+local pre_has_virt_lines = false
+for _, mark in ipairs(pre_marks) do
+	local details = mark[4]
+	if details and details.virt_lines
+		and #details.virt_lines > 0 then
+		pre_has_virt_lines = true
+		break
+	end
+end
+assert_true(
+	not pre_has_virt_lines,
+	"inline comments should not show virt_lines before toggle"
+)
+
+-- Toggle inline comments on
+review_panel.toggle_inline_comments()
+assert_equals(
+	review_panel.state.show_inline_comments, true,
+	"show_inline_comments should be true after toggle"
+)
+
+-- After toggle: extmarks should have virt_lines with comment bodies
+local post_marks = vim.api.nvim_buf_get_extmarks(
+	inline_buf, ns_comments, 0, -1, { details = true }
+)
+local post_has_virt_lines = false
+local virt_lines_contain_body = false
+for _, mark in ipairs(post_marks) do
+	local details = mark[4]
+	if details and details.virt_lines
+		and #details.virt_lines > 0 then
+		post_has_virt_lines = true
+		for _, vl in ipairs(details.virt_lines) do
+			for _, chunk in ipairs(vl) do
+				if chunk[1]:find("Consider renaming", 1, true) then
+					virt_lines_contain_body = true
+				end
+			end
+		end
+	end
+end
+assert_true(
+	post_has_virt_lines,
+	"inline comments should show virt_lines after toggle on"
+)
+assert_true(
+	virt_lines_contain_body,
+	"inline virt_lines should contain comment body text"
+)
+
+-- Toggle inline comments off again
+review_panel.toggle_inline_comments()
+assert_equals(
+	review_panel.state.show_inline_comments, false,
+	"show_inline_comments should be false after second toggle"
+)
+
+local off_marks = vim.api.nvim_buf_get_extmarks(
+	inline_buf, ns_comments, 0, -1, { details = true }
+)
+local off_has_virt_lines = false
+for _, mark in ipairs(off_marks) do
+	local details = mark[4]
+	if details and details.virt_lines
+		and #details.virt_lines > 0 then
+		off_has_virt_lines = true
+		break
+	end
+end
+assert_true(
+	not off_has_virt_lines,
+	"inline comments should not show virt_lines after toggle off"
+)
+
 -- B3: close review panel to restore previous window
 review_panel.close()
 assert_true(


### PR DESCRIPTION
Closes #296

## Summary

- **What changed**: Added a `<leader>i` toggle in the PR review panel that
  switches inline comment display between count-only mode (`[N comments]`)
  and expanded mode showing full comment bodies as virtual lines below diff
  lines.
- **Why**: Users could see that inline comments existed on diff lines but had
  to scroll to the "Review Comments" section at the top to read the content.
  This toggle provides immediate inline visibility.
- **Key decisions**:
  - Used Neovim `virt_lines` extmark feature to render comment bodies below
    diff lines — no buffer content changes needed, preserving cursor/anchor
    stability.
  - `<leader>i` follows the existing `<leader>` prefix convention for
    review panel keybindings (like `<leader>t`, `<leader>b`).
  - State resets on panel close; persists across re-render/refresh cycles.

## Files changed

- `lua/gitflow/panels/review.lua` — Added `show_inline_comments` state,
  `toggle_inline_comments()` function, `<leader>i` keybinding, and
  `virt_lines` rendering in the comment extmark block.
- `KEYBINDINGS.md` — Documented the new `<leader>i` keybinding.
- `scripts/test_stage5.lua` — Added tests for keymap presence, default state,
  toggle on (virt_lines with comment body), and toggle off.

## Testing/Installing/Reviewing

```sh
# Run stage 5 review panel tests
nvim --headless -u NONE -l scripts/test_stage5.lua

# Run full regression suite
for i in 1 2 3 4 5 6 7; do
  nvim --headless -u NONE -l scripts/test_stage${i}.lua
done

# Run E2E tests
for f in tests/e2e/*.lua; do
  nvim --headless -u tests/minimal_init.lua -l "$f"
done
```

All tests pass with 0 failures.

[github-buddy]