### PR TITLE
Issue #307: [Phase 5:] Panel-local keybinding customization (from #297)

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -236,12 +236,12 @@ Buffer-local bindings in the merged pane of the 3-way conflict editor.
 
 Buffer-local bindings active in the label panel (`:Gitflow label list`).
 
-| Key | Action |
-| --- | --- |
-| `c` | Create new label |
-| `d` | Delete label under cursor |
-| `r` | Refresh |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `c` | Create new label | `create` |
+| `d` | Delete label under cursor | `delete` |
+| `r` | Refresh | `refresh` |
+| `q` | Close | `close` |
 
 ## Command Palette
 
@@ -249,21 +249,32 @@ Bindings active in the command palette (`:Gitflow palette`).
 
 ### Prompt (Insert/Normal Mode)
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | Select highlighted command |
-| `<Esc>` | Close palette |
-| `<Down>` / `<C-n>` / `<Tab>` / `<C-j>` | Move selection down |
-| `<Up>` / `<C-p>` / `<S-Tab>` / `<C-k>` | Move selection up |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `<CR>` | Select highlighted command | `prompt_submit` |
+| `<Esc>` | Close palette | `prompt_close` |
+| `<Down>` | Move selection down | `prompt_next_down` |
+| `<C-n>` | Move selection down | `prompt_next_ctrl_n` |
+| `<Tab>` | Move selection down | `prompt_next_tab` |
+| `<C-j>` | Move selection down | `prompt_next_ctrl_j` |
+| `<Up>` | Move selection up | `prompt_prev_up` |
+| `<C-p>` | Move selection up | `prompt_prev_ctrl_p` |
+| `<S-Tab>` | Move selection up | `prompt_prev_shift_tab` |
+| `<C-k>` | Move selection up | `prompt_prev_ctrl_k` |
+| `1`-`9` | Quick-select numbered entries | `quick_select_1` ... `quick_select_9` |
 
 ### List (Normal Mode)
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | Select highlighted command |
-| `j` / `<C-n>` | Move selection down |
-| `k` / `<C-p>` | Move selection up |
-| `q` / `<Esc>` | Close palette |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `<CR>` | Select highlighted command | `list_submit` |
+| `j` | Move selection down | `list_next_j` |
+| `<C-n>` | Move selection down | `list_next_ctrl_n` |
+| `k` | Move selection up | `list_prev_k` |
+| `<C-p>` | Move selection up | `list_prev_ctrl_p` |
+| `q` | Close palette | `list_close` |
+| `<Esc>` | Close palette | `list_close_esc` |
+| `1`-`9` | Quick-select numbered entries | `quick_select_1` ... `quick_select_9` |
 
 ## Overriding Keybindings
 
@@ -315,4 +326,5 @@ defaults. Validation rejects duplicate keys within the same panel
 (e.g., mapping two actions to the same key).
 
 Valid panel names: `status`, `branch`, `diff`, `review`, `conflict`,
-`issues`, `prs`, `log`, `stash`, `reset`, `revert`, `cherry_pick`.
+`issues`, `prs`, `log`, `stash`, `reset`, `revert`, `cherry_pick`,
+`labels`, `palette`.

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -36,79 +36,84 @@ Normal-mode mappings available in any buffer. Configured via
 
 Buffer-local bindings active in the status panel (`:Gitflow status`).
 
-| Key | Action |
-| --- | --- |
-| `s` | Stage file under cursor |
-| `u` | Unstage file under cursor |
-| `a` | Stage all files |
-| `A` | Unstage all files |
-| `cc` | Commit |
-| `dd` | Open diff for file under cursor |
-| `cx` | Open conflict resolution for file |
-| `p` | Push |
-| `X` | Revert uncommitted changes in file |
-| `r` | Refresh |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `s` | Stage file under cursor | `stage` |
+| `u` | Unstage file under cursor | `unstage` |
+| `a` | Stage all files | `stage_all` |
+| `A` | Unstage all files | `unstage_all` |
+| `cc` | Commit | `commit` |
+| `dd` | Open diff for file under cursor | `diff` |
+| `cx` | Open conflict resolution for file | `conflicts` |
+| `p` | Push | `push` |
+| `X` | Revert uncommitted changes in file | `revert` |
+| `r` | Refresh | `refresh` |
+| `q` | Close | `close` |
 
 ## Diff View
 
 Buffer-local bindings active in diff buffers (`:Gitflow diff`).
 
-| Key | Action |
-| --- | --- |
-| `r` | Refresh diff |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `q` | Close | `close` |
+| `r` | Refresh diff | `refresh` |
+| `]f` | Jump to next file | `next_file` |
+| `[f` | Jump to previous file | `prev_file` |
+| `]c` | Jump to next hunk | `next_hunk` |
+| `[c` | Jump to previous hunk | `prev_hunk` |
 
 ## Branch List
 
 Buffer-local bindings active in the branch panel (`:Gitflow branch`).
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | Switch to branch under cursor |
-| `c` | Create new branch |
-| `d` | Delete branch |
-| `D` | Force delete branch |
-| `m` | Merge branch into current |
-| `r` | Rename branch |
-| `R` | Refresh branch list |
-| `f` | Fetch remote branches |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `<CR>` | Switch to branch under cursor | `switch` |
+| `c` | Create new branch | `create` |
+| `d` | Delete branch | `delete` |
+| `D` | Force delete branch | `force_delete` |
+| `r` | Rename branch | `rename` |
+| `R` | Refresh branch list | `refresh` |
+| `f` | Fetch remote branches | `fetch` |
+| `m` | Merge branch into current | `merge` |
+| `G` | Toggle list/graph view | `toggle_graph` |
+| `q` | Close | `close` |
 
 ## Log View
 
 Buffer-local bindings active in the log panel (`:Gitflow log`).
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | Open diff for commit under cursor |
-| `r` | Refresh |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `<CR>` | Open diff for commit under cursor | `open_commit` |
+| `r` | Refresh | `refresh` |
+| `q` | Close | `close` |
 
 ## Reset Panel
 
 Buffer-local bindings active in the reset panel (`:Gitflow reset`).
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | Select commit under cursor (prompts soft/hard) |
-| `1`-`9` | Select commit by position (prompts soft/hard) |
-| `S` | Soft reset to commit under cursor |
-| `H` | Hard reset to commit under cursor |
-| `r` | Refresh |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `<CR>` | Select commit under cursor (prompts soft/hard) | `select` |
+| `1`-`9` | Select commit by position (prompts soft/hard) | — |
+| `S` | Soft reset to commit under cursor | `soft_reset` |
+| `H` | Hard reset to commit under cursor | `hard_reset` |
+| `r` | Refresh | `refresh` |
+| `q` | Close | `close` |
 
 ## Stash Panel
 
 Buffer-local bindings active in the stash panel (`:Gitflow stash list`).
 
-| Key | Action |
-| --- | --- |
-| `P` | Pop stash entry under cursor |
-| `D` | Drop stash entry under cursor |
-| `S` | Stash with message prompt |
-| `r` | Refresh |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `P` | Pop stash entry under cursor | `pop` |
+| `D` | Drop stash entry under cursor | `drop` |
+| `S` | Stash with message prompt | `stash` |
+| `r` | Refresh | `refresh` |
+| `q` | Close | `close` |
 
 ## Issue List
 
@@ -116,27 +121,29 @@ Buffer-local bindings active in the issue panel (`:Gitflow issue list`).
 
 ### List View
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | View issue under cursor |
-| `c` | Create new issue |
-| `C` | Comment on issue |
-| `x` | Close issue |
-| `L` | Edit labels |
-| `r` | Refresh |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `<CR>` | View issue under cursor | `view` |
+| `c` | Create new issue | `create` |
+| `C` | Comment on issue | `comment` |
+| `x` | Close issue | `close_issue` |
+| `L` | Edit labels | `labels` |
+| `A` | Edit assignees | `assign` |
+| `r` | Refresh | `refresh` |
+| `q` | Close | `close` |
 
 ### Detail View
 
-| Key | Action |
-| --- | --- |
-| `b` | Back to list |
-| `c` | Create new issue |
-| `C` | Comment on issue |
-| `x` | Close issue |
-| `L` | Edit labels |
-| `r` | Refresh |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `b` | Back to list | `back` |
+| `c` | Create new issue | `create` |
+| `C` | Comment on issue | `comment` |
+| `x` | Close issue | `close_issue` |
+| `L` | Edit labels | `labels` |
+| `A` | Edit assignees | `assign` |
+| `r` | Refresh | `refresh` |
+| `q` | Close | `close` |
 
 ## PR List
 
@@ -144,52 +151,55 @@ Buffer-local bindings active in the PR panel (`:Gitflow pr list`).
 
 ### List View
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | View PR under cursor |
-| `c` | Create new PR |
-| `C` | Comment on PR |
-| `L` | Edit labels |
-| `m` | Merge PR |
-| `o` | Checkout PR branch |
-| `v` | Open review panel |
-| `r` | Refresh |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `<CR>` | View PR under cursor | `view` |
+| `c` | Create new PR | `create` |
+| `C` | Comment on PR | `comment` |
+| `L` | Edit labels | `labels` |
+| `A` | Edit assignees | `assign` |
+| `m` | Merge PR | `merge` |
+| `o` | Checkout PR branch | `checkout` |
+| `v` | Open review panel | `review` |
+| `r` | Refresh | `refresh` |
+| `q` | Close | `close` |
 
 ### Detail View
 
-| Key | Action |
-| --- | --- |
-| `b` | Back to list |
-| `c` | Create new PR |
-| `C` | Comment on PR |
-| `L` | Edit labels |
-| `m` | Merge PR |
-| `o` | Checkout PR branch |
-| `v` | Open review panel |
-| `r` | Refresh |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `b` | Back to list | `back` |
+| `c` | Create new PR | `create` |
+| `C` | Comment on PR | `comment` |
+| `L` | Edit labels | `labels` |
+| `A` | Edit assignees | `assign` |
+| `m` | Merge PR | `merge` |
+| `o` | Checkout PR branch | `checkout` |
+| `v` | Open review panel | `review` |
+| `r` | Refresh | `refresh` |
+| `q` | Close | `close` |
 
 ## Review View
 
 Buffer-local bindings active in the review panel (`:Gitflow pr review`).
 
-| Key | Action |
-| --- | --- |
-| `]f` | Jump to next file |
-| `[f` | Jump to previous file |
-| `]c` | Jump to next hunk |
-| `[c` | Jump to previous hunk |
-| `a` | Approve review |
-| `x` | Request changes |
-| `c` | Inline comment on current line (normal and visual mode) |
-| `S` | Submit pending review |
-| `R` | Reply to comment thread |
-| `<leader>t` | Toggle thread collapse/expand |
-| `<leader>i` | Toggle inline comment bodies on diff lines |
-| `<leader>b` | Back to PR view |
-| `r` | Refresh |
-| `q` | Close (confirms if pending comments exist) |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `]f` | Jump to next file | `next_file` |
+| `[f` | Jump to previous file | `prev_file` |
+| `]c` | Jump to next hunk | `next_hunk` |
+| `[c` | Jump to previous hunk | `prev_hunk` |
+| `a` | Approve review | `approve` |
+| `x` | Request changes | `request_changes` |
+| `c` | Inline comment (normal mode) | `inline_comment` |
+| `c` | Inline comment (visual mode) | `inline_comment_visual` |
+| `S` | Submit pending review | `submit_review` |
+| `R` | Reply to comment thread | `reply` |
+| `<leader>t` | Toggle thread collapse/expand | `toggle_thread` |
+| `<leader>i` | Toggle inline comment bodies | `toggle_inline` |
+| `<leader>b` | Back to PR view | `back_to_pr` |
+| `r` | Refresh | `refresh` |
+| `q` | Close (confirms if pending) | `close` |
 
 ## Conflict Resolution
 
@@ -197,14 +207,14 @@ Buffer-local bindings active in the review panel (`:Gitflow pr review`).
 
 Buffer-local bindings in the conflict list (`:Gitflow conflicts`).
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | Open 3-way conflict view |
-| `r` | Refresh conflict list |
-| `R` | Refresh conflict list |
-| `C` | Continue active merge/rebase/cherry-pick |
-| `A` | Abort active operation |
-| `q` | Close |
+| Key | Action | Action Name |
+| --- | --- | --- |
+| `<CR>` | Open 3-way conflict view | `open` |
+| `r` | Refresh conflict list | `refresh` |
+| `R` | Refresh conflict list | `refresh_alias` |
+| `C` | Continue active merge/rebase/cherry-pick | `continue` |
+| `A` | Abort active operation | `abort` |
+| `q` | Close | `close` |
 
 ### 3-Way Merge View
 
@@ -257,6 +267,8 @@ Bindings active in the command palette (`:Gitflow palette`).
 
 ## Overriding Keybindings
 
+### Global Keybindings
+
 Global keybindings are overridden by passing a `keybindings` table to
 `setup()`. Each key in the table corresponds to an action name (listed in
 the Config Key column of the Global table above).
@@ -274,5 +286,33 @@ require("gitflow").setup({
 
 Only the keybindings you specify are changed; all others keep their defaults.
 
-Panel-local keybindings (status, branch, diff, etc.) are not currently
-user-configurable and use the fixed mappings documented above.
+### Panel-Local Keybindings
+
+Panel-local keybindings are overridden via the `panel_keybindings` table.
+Each key is a panel name and each value is a table mapping action names to
+key sequences. Action names are listed in the "Action Name" column of each
+panel table above.
+
+```lua
+require("gitflow").setup({
+  panel_keybindings = {
+    status = {
+      stage   = "S",    -- remap stage from "s" to "S"
+      unstage = "U",    -- remap unstage from "u" to "U"
+    },
+    branch = {
+      create = "n",     -- remap create branch from "c" to "n"
+    },
+    review = {
+      approve = "A",    -- remap approve from "a" to "A"
+    },
+  },
+})
+```
+
+Only the action names you specify are changed; all others keep their
+defaults. Validation rejects duplicate keys within the same panel
+(e.g., mapping two actions to the same key).
+
+Valid panel names: `status`, `branch`, `diff`, `review`, `conflict`,
+`issues`, `prs`, `log`, `stash`, `reset`, `revert`, `cherry_pick`.

--- a/doc/gitflow.txt
+++ b/doc/gitflow.txt
@@ -128,7 +128,11 @@ change; omitted actions keep their defaults. >lua
 <
 
 Valid panel names: `status`, `branch`, `diff`, `review`, `conflict`,
-`issues`, `prs`, `log`, `stash`, `reset`, `revert`, `cherry_pick`.
+`issues`, `prs`, `log`, `stash`, `reset`, `revert`, `cherry_pick`,
+`labels`, `palette`.
+
+Label panel action names: `create`, `delete`, `refresh`, `close`.
+Palette action names: `prompt_*`, `list_*`, and `quick_select_1`..`quick_select_9`.
 
 Validation rejects duplicate keys within the same panel context.
 
@@ -338,20 +342,21 @@ Conflict list ~
     q       Close conflict view
 
 Label panel ~
-    c       Create new label
-    d       Delete label under cursor
-    r       Refresh
-    q       Close
+    c       Create new label (create)
+    d       Delete label under cursor (delete)
+    r       Refresh (refresh)
+    q       Close (close)
 
 Command palette ~
-    <CR>            Select highlighted command
-    <Esc>           Close palette
-    <Down>/<C-n>    Move selection down
-    <Up>/<C-p>      Move selection up
-    <Tab>/<S-Tab>   Move selection down/up
-    <C-j>/<C-k>     Move selection down/up
-    j/k             Move selection (list normal mode)
-    q               Close (list normal mode)
+    <CR>            Select highlighted command (prompt_submit/list_submit)
+    <Esc>           Close palette (prompt_close/list_close_esc)
+    <Down>/<C-n>    Move selection down (prompt_next_down/prompt_next_ctrl_n)
+    <Up>/<C-p>      Move selection up (prompt_prev_up/prompt_prev_ctrl_p)
+    <Tab>/<S-Tab>   Move selection down/up (prompt_next_tab/prompt_prev_shift_tab)
+    <C-j>/<C-k>     Move selection down/up (prompt_next_ctrl_j/prompt_prev_ctrl_k)
+    j/k             Move selection (list_next_j/list_prev_k)
+    q               Close list (list_close)
+    1..9            Quick-select numbered entries (quick_select_1..quick_select_9)
 
 ==============================================================================
 8. HIGHLIGHTS                                            *gitflow-highlights*

--- a/doc/gitflow.txt
+++ b/doc/gitflow.txt
@@ -110,6 +110,30 @@ Default keybindings:
     conflict        <leader>gm          <Plug>(GitflowConflicts)
     palette         <leader>gp          <Plug>(GitflowPalette)
 
+                                                *gitflow-panel-keybindings*
+panel_keybindings ~
+
+Table of per-panel override tables. Each key is a panel name, each value
+maps action names to key sequences. Override only the bindings you want to
+change; omitted actions keep their defaults. >lua
+    panel_keybindings = {
+      status = {
+        stage   = "S",
+        unstage = "U",
+      },
+      review = {
+        approve = "A",
+      },
+    }
+<
+
+Valid panel names: `status`, `branch`, `diff`, `review`, `conflict`,
+`issues`, `prs`, `log`, `stash`, `reset`, `revert`, `cherry_pick`.
+
+Validation rejects duplicate keys within the same panel context.
+
+See |KEYBINDINGS.md| for the complete list of action names per panel.
+
                                                           *gitflow-config-ui*
 ui ~
 
@@ -213,9 +237,10 @@ GitHub ~
 7. KEYBINDINGS                                          *gitflow-keybindings*
 
 See |gitflow-config-keybindings| for global mappings.
+See |gitflow-panel-keybindings| for per-panel overrides.
 
-Panel-local keybindings are set on each panel buffer. These are fixed and
-cannot be overridden through configuration.
+Panel-local keybindings are set on each panel buffer. Defaults are listed
+below and can be overridden via `panel_keybindings` in setup().
 
 Status panel ~
     s       Stage file under cursor

--- a/lua/gitflow/config.lua
+++ b/lua/gitflow/config.lua
@@ -277,6 +277,32 @@ local PANEL_ACTION_MODES = {
 	},
 }
 
+local RESERVED_POSITIONAL_KEYS = {
+	["1"] = true,
+	["2"] = true,
+	["3"] = true,
+	["4"] = true,
+	["5"] = true,
+	["6"] = true,
+	["7"] = true,
+	["8"] = true,
+	["9"] = true,
+}
+
+local PANELS_WITH_RESERVED_POSITIONAL_KEYS = {
+	reset = true,
+	revert = true,
+	cherry_pick = true,
+}
+
+---@param panel string
+---@param mapping string
+---@return boolean
+local function has_reserved_positional_key(panel, mapping)
+	return PANELS_WITH_RESERVED_POSITIONAL_KEYS[panel]
+		and RESERVED_POSITIONAL_KEYS[mapping]
+end
+
 ---@param panel string
 ---@param action string
 ---@return string[]
@@ -337,6 +363,17 @@ local function validate_panel_keybindings(config)
 					("gitflow config error:"
 						.. " panel_keybindings.%s.%s must be a"
 						.. " non-empty string"):format(panel, action),
+					3
+				)
+			end
+			if has_reserved_positional_key(panel, mapping) then
+				error(
+					("gitflow config error:"
+						.. " panel_keybindings.%s.%s uses reserved"
+						.. " positional key '%s' (1-9 are fixed"
+						.. " shortcuts for this panel)"):format(
+							panel, action, mapping
+						),
 					3
 				)
 			end

--- a/lua/gitflow/panels/branch.lua
+++ b/lua/gitflow/panels/branch.lua
@@ -20,11 +20,24 @@ local M = {}
 local BRANCH_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_branch_hl")
 local GRAPH_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_branch_graph_hl")
 local BRANCH_FLOAT_TITLE = "Gitflow Branches"
-local LIST_FOOTER =
-	"<CR> switch  c create  d delete  D force delete  m merge"
-	.. "  r rename  R refresh  f fetch  G graph  q close"
-local GRAPH_FOOTER =
-	"R refresh  f fetch  G list  q close"
+local LIST_FOOTER_HINTS = {
+	{ action = "switch", default = "<CR>", label = "switch" },
+	{ action = "create", default = "c", label = "create" },
+	{ action = "delete", default = "d", label = "delete" },
+	{ action = "force_delete", default = "D", label = "force delete" },
+	{ action = "merge", default = "m", label = "merge" },
+	{ action = "rename", default = "r", label = "rename" },
+	{ action = "refresh", default = "R", label = "refresh" },
+	{ action = "fetch", default = "f", label = "fetch" },
+	{ action = "toggle_graph", default = "G", label = "graph" },
+	{ action = "close", default = "q", label = "close" },
+}
+local GRAPH_FOOTER_HINTS = {
+	{ action = "refresh", default = "R", label = "refresh" },
+	{ action = "fetch", default = "f", label = "fetch" },
+	{ action = "toggle_graph", default = "G", label = "list" },
+	{ action = "close", default = "q", label = "close" },
+}
 
 ---@type GitflowBranchPanelState
 M.state = {
@@ -49,12 +62,18 @@ local function result_message(result, fallback)
 	return output
 end
 
+---@param cfg GitflowConfig|nil
 ---@return string
-local function current_footer()
+local function current_footer(cfg)
+	local active_cfg = cfg or M.state.cfg
 	if M.state.view_mode == "graph" then
-		return GRAPH_FOOTER
+		return ui_render.resolve_panel_key_hints(
+			active_cfg, "branch", GRAPH_FOOTER_HINTS
+		)
 	end
-	return LIST_FOOTER
+	return ui_render.resolve_panel_key_hints(
+		active_cfg, "branch", LIST_FOOTER_HINTS
+	)
 end
 
 ---@param bufnr integer|nil
@@ -114,7 +133,7 @@ local function ensure_window(cfg)
 			border = cfg.ui.float.border,
 			title = BRANCH_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
-			footer = cfg.ui.float.footer and current_footer() or nil,
+			footer = cfg.ui.float.footer and current_footer(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil
@@ -685,7 +704,7 @@ function M.toggle_view()
 				and cfg.ui.float.footer
 			if footer_enabled and vim.fn.has("nvim-0.10") == 1 then
 				pcall(vim.api.nvim_win_set_config, M.state.winid, {
-					footer = current_footer(),
+					footer = current_footer(cfg),
 				})
 			end
 		end

--- a/lua/gitflow/panels/branch.lua
+++ b/lua/gitflow/panels/branch.lua
@@ -4,6 +4,7 @@ local git = require("gitflow.git")
 local git_branch = require("gitflow.git.branch")
 local icons = require("gitflow.icons")
 local ui_render = require("gitflow.ui.render")
+local config = require("gitflow.config")
 
 ---@class GitflowBranchPanelState
 ---@field bufnr integer|nil
@@ -131,43 +132,53 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "<CR>", function()
+	local key = config.resolve_panel_key(cfg, "branch", "switch", "<CR>")
+	vim.keymap.set("n", key, function()
 		M.switch_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
-	vim.keymap.set("n", "c", function()
+	key = config.resolve_panel_key(cfg, "branch", "create", "c")
+	vim.keymap.set("n", key, function()
 		M.create_branch()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "d", function()
+	key = config.resolve_panel_key(cfg, "branch", "delete", "d")
+	vim.keymap.set("n", key, function()
 		M.delete_under_cursor(false)
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "D", function()
+	key = config.resolve_panel_key(cfg, "branch", "force_delete", "D")
+	vim.keymap.set("n", key, function()
 		M.delete_under_cursor(true)
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "r", function()
+	key = config.resolve_panel_key(cfg, "branch", "rename", "r")
+	vim.keymap.set("n", key, function()
 		M.rename_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "R", function()
+	key = config.resolve_panel_key(cfg, "branch", "refresh", "R")
+	vim.keymap.set("n", key, function()
 		M.refresh_with_fetch()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "f", function()
+	key = config.resolve_panel_key(cfg, "branch", "fetch", "f")
+	vim.keymap.set("n", key, function()
 		M.fetch_remotes()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "m", function()
+	key = config.resolve_panel_key(cfg, "branch", "merge", "m")
+	vim.keymap.set("n", key, function()
 		M.merge_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "G", function()
+	key = config.resolve_panel_key(cfg, "branch", "toggle_graph", "G")
+	vim.keymap.set("n", key, function()
 		M.toggle_view()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	key = config.resolve_panel_key(cfg, "branch", "close", "q")
+	vim.keymap.set("n", key, function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/cherry_pick.lua
+++ b/lua/gitflow/panels/cherry_pick.lua
@@ -23,8 +23,13 @@ local config = require("gitflow.config")
 
 local M = {}
 local CP_FLOAT_TITLE = "Gitflow Cherry Pick"
-local CP_FLOAT_FOOTER_COMMITS =
-	"<CR> pick  B into branch  b branches  r refresh  q close"
+local CP_FLOAT_FOOTER_HINTS = {
+	{ action = "select", default = "<CR>", label = "pick" },
+	{ action = "pick_into_branch", default = "B", label = "into branch" },
+	{ action = "branch_picker", default = "b", label = "branches" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "close", default = "q", label = "close" },
+}
 local CP_HIGHLIGHT_NS =
 	vim.api.nvim_create_namespace("gitflow_cherry_pick_hl")
 
@@ -103,6 +108,14 @@ local function emit_post_operation()
 end
 
 ---@param cfg GitflowConfig
+---@return string
+local function cherry_pick_float_footer(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg, "cherry_pick", CP_FLOAT_FOOTER_HINTS
+	)
+end
+
+---@param cfg GitflowConfig
 local function ensure_window(cfg)
 	local bufnr = M.state.bufnr
 		and vim.api.nvim_buf_is_valid(M.state.bufnr)
@@ -136,7 +149,7 @@ local function ensure_window(cfg)
 			title = CP_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
 			footer = cfg.ui.float.footer
-				and CP_FLOAT_FOOTER_COMMITS or nil,
+				and cherry_pick_float_footer(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil

--- a/lua/gitflow/panels/cherry_pick.lua
+++ b/lua/gitflow/panels/cherry_pick.lua
@@ -8,6 +8,7 @@ local icons = require("gitflow.icons")
 local ui_render = require("gitflow.ui.render")
 local list_picker = require("gitflow.ui.list_picker")
 local status_panel = require("gitflow.panels.status")
+local config = require("gitflow.config")
 
 ---@class GitflowCherryPickPanelState
 ---@field bufnr integer|nil
@@ -153,7 +154,13 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "<CR>", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "cherry_pick", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("select", "<CR>"), function()
 		M.select_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
@@ -163,21 +170,33 @@ local function ensure_window(cfg)
 		end, { buffer = bufnr, silent = true, nowait = true })
 	end
 
-	vim.keymap.set("n", "B", function()
-		M.cherry_pick_into_branch()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"n", pk("pick_into_branch", "B"), function()
+			M.cherry_pick_into_branch()
+		end,
+		{ buffer = bufnr, silent = true, nowait = true }
+	)
 
-	vim.keymap.set("n", "b", function()
-		M.show_branch_picker()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"n", pk("branch_picker", "b"), function()
+			M.show_branch_picker()
+		end,
+		{ buffer = bufnr, silent = true, nowait = true }
+	)
 
-	vim.keymap.set("n", "r", function()
-		M.refresh()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"n", pk("refresh", "r"), function()
+			M.refresh()
+		end,
+		{ buffer = bufnr, silent = true, nowait = true }
+	)
 
-	vim.keymap.set("n", "q", function()
-		M.close()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"n", pk("close", "q"), function()
+			M.close()
+		end,
+		{ buffer = bufnr, silent = true, nowait = true }
+	)
 end
 
 ---@param commits GitflowCherryPickEntry[]

--- a/lua/gitflow/panels/conflict.lua
+++ b/lua/gitflow/panels/conflict.lua
@@ -26,8 +26,13 @@ local config = require("gitflow.config")
 local M = {}
 local CONFLICT_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_conflict_hl")
 local CONFLICT_FLOAT_TITLE = "Gitflow Conflicts"
-local CONFLICT_FLOAT_FOOTER =
-	"<CR> open 3-way  r refresh  C continue  A abort  q close"
+local CONFLICT_FLOAT_FOOTER_HINTS = {
+	{ action = "open", default = "<CR>", label = "open 3-way" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "continue", default = "C", label = "continue" },
+	{ action = "abort", default = "A", label = "abort" },
+	{ action = "close", default = "q", label = "close" },
+}
 
 ---@type GitflowConflictPanelState
 M.state = {
@@ -84,6 +89,14 @@ local function reset_auto_continue_prompt()
 end
 
 ---@param cfg GitflowConfig
+---@return string
+local function conflict_float_footer(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg, "conflict", CONFLICT_FLOAT_FOOTER_HINTS
+	)
+end
+
+---@param cfg GitflowConfig
 local function ensure_window(cfg)
 	local bufnr = M.state.bufnr and vim.api.nvim_buf_is_valid(M.state.bufnr) and M.state.bufnr or nil
 	if not bufnr then
@@ -110,7 +123,7 @@ local function ensure_window(cfg)
 			border = cfg.ui.float.border,
 			title = CONFLICT_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
-			footer = cfg.ui.float.footer and CONFLICT_FLOAT_FOOTER or nil,
+			footer = cfg.ui.float.footer and conflict_float_footer(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil

--- a/lua/gitflow/panels/conflict.lua
+++ b/lua/gitflow/panels/conflict.lua
@@ -4,6 +4,7 @@ local git = require("gitflow.git")
 local git_conflict = require("gitflow.git.conflict")
 local conflict_view = require("gitflow.ui.conflict")
 local ui_render = require("gitflow.ui.render")
+local config = require("gitflow.config")
 
 ---@class GitflowConflictFileEntry
 ---@field path string
@@ -127,27 +128,33 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "<CR>", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "conflict", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("open", "<CR>"), function()
 		M.open_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "R", function()
+	vim.keymap.set("n", pk("refresh_alias", "R"), function()
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "C", function()
+	vim.keymap.set("n", pk("continue", "C"), function()
 		M.continue_operation()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "A", function()
+	vim.keymap.set("n", pk("abort", "A"), function()
 		M.abort_operation()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/diff.lua
+++ b/lua/gitflow/panels/diff.lua
@@ -3,6 +3,7 @@ local ui_render = require("gitflow.ui.render")
 local utils = require("gitflow.utils")
 local git_diff = require("gitflow.git.diff")
 local git_branch = require("gitflow.git.branch")
+local config = require("gitflow.config")
 
 ---@class GitflowDiffPanelState
 ---@field bufnr integer|nil
@@ -179,29 +180,35 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "q", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "diff", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		if M.state.request then
 			M.open(cfg, M.state.request)
 		end
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "]f", function()
+	vim.keymap.set("n", pk("next_file", "]f"), function()
 		M.next_file()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "[f", function()
+	vim.keymap.set("n", pk("prev_file", "[f"), function()
 		M.prev_file()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "]c", function()
+	vim.keymap.set("n", pk("next_hunk", "]c"), function()
 		M.next_hunk()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "[c", function()
+	vim.keymap.set("n", pk("prev_hunk", "[c"), function()
 		M.prev_hunk()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/diff.lua
+++ b/lua/gitflow/panels/diff.lua
@@ -17,8 +17,14 @@ local M = {}
 local DIFF_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_diff_hl")
 local DIFF_LINENR_NS = vim.api.nvim_create_namespace("gitflow_diff_linenr")
 local DIFF_FLOAT_TITLE = "Gitflow Diff"
-local DIFF_FLOAT_FOOTER =
-	"]f/[f files  ]c/[c hunks  r refresh  q close"
+local DIFF_FLOAT_FOOTER_HINTS = {
+	{ action = "next_file", default = "]f", label = "next file" },
+	{ action = "prev_file", default = "[f", label = "prev file" },
+	{ action = "next_hunk", default = "]c", label = "next hunk" },
+	{ action = "prev_hunk", default = "[c", label = "prev hunk" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "close", default = "q", label = "close" },
+}
 
 ---@type GitflowDiffPanelState
 M.state = {
@@ -124,6 +130,14 @@ function M.prev_hunk()
 end
 
 ---@param cfg GitflowConfig
+---@return string
+local function diff_float_footer(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg, "diff", DIFF_FLOAT_FOOTER_HINTS
+	)
+end
+
+---@param cfg GitflowConfig
 local function ensure_window(cfg)
 	local bufnr = M.state.bufnr
 		and vim.api.nvim_buf_is_valid(M.state.bufnr)
@@ -162,7 +176,7 @@ local function ensure_window(cfg)
 			title = DIFF_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
 			footer = cfg.ui.float.footer
-				and DIFF_FLOAT_FOOTER or nil,
+				and diff_float_footer(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil

--- a/lua/gitflow/panels/issues.lua
+++ b/lua/gitflow/panels/issues.lua
@@ -25,9 +25,17 @@ local config = require("gitflow.config")
 local M = {}
 local ISSUES_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_issues_hl")
 local ISSUES_FLOAT_TITLE = "Gitflow Issues"
-local ISSUES_FLOAT_FOOTER =
-	"<CR> view  c create  C comment  x close  L labels  A assign"
-	.. "  r refresh  b back  q close"
+local ISSUES_FLOAT_FOOTER_HINTS = {
+	{ action = "view", default = "<CR>", label = "view" },
+	{ action = "create", default = "c", label = "create" },
+	{ action = "comment", default = "C", label = "comment" },
+	{ action = "close_issue", default = "x", label = "close issue" },
+	{ action = "labels", default = "L", label = "labels" },
+	{ action = "assign", default = "A", label = "assign" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "back", default = "b", label = "back" },
+	{ action = "close", default = "q", label = "close panel" },
+}
 
 ---@type GitflowIssuePanelState
 M.state = {
@@ -39,6 +47,14 @@ M.state = {
 	mode = "list",
 	active_issue_number = nil,
 }
+
+---@param cfg GitflowConfig
+---@return string
+local function issues_float_footer(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg, "issues", ISSUES_FLOAT_FOOTER_HINTS
+	)
+end
 
 ---@param cfg GitflowConfig
 local function ensure_window(cfg)
@@ -67,7 +83,7 @@ local function ensure_window(cfg)
 			border = cfg.ui.float.border,
 			title = ISSUES_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
-			footer = cfg.ui.float.footer and ISSUES_FLOAT_FOOTER or nil,
+			footer = cfg.ui.float.footer and issues_float_footer(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil

--- a/lua/gitflow/panels/issues.lua
+++ b/lua/gitflow/panels/issues.lua
@@ -11,6 +11,7 @@ local label_picker = require("gitflow.ui.label_picker")
 local list_picker = require("gitflow.ui.list_picker")
 local icons = require("gitflow.icons")
 local highlights = require("gitflow.highlights")
+local config = require("gitflow.config")
 
 ---@class GitflowIssuePanelState
 ---@field bufnr integer|nil
@@ -84,31 +85,37 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "<CR>", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "issues", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("view", "<CR>"), function()
 		M.view_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
-	vim.keymap.set("n", "c", function()
+	vim.keymap.set("n", pk("create", "c"), function()
 		M.create_interactive()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "C", function()
+	vim.keymap.set("n", pk("comment", "C"), function()
 		M.comment_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "x", function()
+	vim.keymap.set("n", pk("close_issue", "x"), function()
 		M.close_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "L", function()
+	vim.keymap.set("n", pk("labels", "L"), function()
 		M.edit_labels_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "A", function()
+	vim.keymap.set("n", pk("assign", "A"), function()
 		M.edit_assignees_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		if M.state.mode == "view" and M.state.active_issue_number then
 			M.open_view(M.state.active_issue_number)
 			return
@@ -116,14 +123,14 @@ local function ensure_window(cfg)
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "b", function()
+	vim.keymap.set("n", pk("back", "b"), function()
 		if M.state.mode == "view" then
 			M.state.mode = "list"
 			M.refresh()
 		end
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/labels.lua
+++ b/lua/gitflow/panels/labels.lua
@@ -9,7 +9,12 @@ local config = require("gitflow.config")
 
 local LABELS_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_labels_hl")
 local LABELS_FLOAT_TITLE = "Gitflow Labels"
-local LABELS_FLOAT_FOOTER = "c create  d delete  r refresh  q close"
+local LABELS_KEY_HINTS = {
+	{ action = "create", default = "c", label = "create" },
+	{ action = "delete", default = "d", label = "delete" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "close", default = "q", label = "close" },
+}
 
 ---@class GitflowLabelPanelState
 ---@field bufnr integer|nil
@@ -26,6 +31,14 @@ M.state = {
 	cfg = nil,
 	line_entries = {},
 }
+
+---@param cfg GitflowConfig|nil
+---@return string
+local function labels_key_hints(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg or config.current, "labels", LABELS_KEY_HINTS
+	)
+end
 
 ---@param cfg GitflowConfig
 local function ensure_window(cfg)
@@ -54,7 +67,7 @@ local function ensure_window(cfg)
 			border = cfg.ui.float.border,
 			title = LABELS_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
-			footer = cfg.ui.float.footer and LABELS_FLOAT_FOOTER or nil,
+			footer = cfg.ui.float.footer and labels_key_hints(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil
@@ -147,12 +160,7 @@ local function render_list(labels)
 		end
 	end
 
-	local key_hints = ui_render.format_key_hints({
-		{ "c", "create" },
-		{ "d", "delete" },
-		{ "r", "refresh" },
-		{ "q", "quit" },
-	})
+	local key_hints = labels_key_hints(M.state.cfg or config.current)
 	local footer_lines = ui_render.panel_footer(nil, key_hints, render_opts)
 	for _, line in ipairs(footer_lines) do
 		lines[#lines + 1] = line

--- a/lua/gitflow/panels/labels.lua
+++ b/lua/gitflow/panels/labels.lua
@@ -5,6 +5,7 @@ local input = require("gitflow.ui.input")
 local form = require("gitflow.ui.form")
 local gh_labels = require("gitflow.gh.labels")
 local highlights = require("gitflow.highlights")
+local config = require("gitflow.config")
 
 local LABELS_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_labels_hl")
 local LABELS_FLOAT_TITLE = "Gitflow Labels"
@@ -71,19 +72,25 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "c", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "labels", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("create", "c"), function()
 		M.create_interactive()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "d", function()
+	vim.keymap.set("n", pk("delete", "d"), function()
 		M.delete_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/log.lua
+++ b/lua/gitflow/panels/log.lua
@@ -18,7 +18,11 @@ local config = require("gitflow.config")
 
 local M = {}
 local LOG_FLOAT_TITLE = "Gitflow Log"
-local LOG_FLOAT_FOOTER = "<CR> open commit diff  r refresh  q close"
+local LOG_FLOAT_FOOTER_HINTS = {
+	{ action = "open_commit", default = "<CR>", label = "open commit diff" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "close", default = "q", label = "close" },
+}
 local LOG_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_log_hl")
 
 ---@type GitflowLogPanelState
@@ -29,6 +33,14 @@ M.state = {
 	cfg = nil,
 	opts = {},
 }
+
+---@param cfg GitflowConfig
+---@return string
+local function log_float_footer(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg, "log", LOG_FLOAT_FOOTER_HINTS
+	)
+end
 
 ---@param cfg GitflowConfig
 local function ensure_window(cfg)
@@ -57,7 +69,7 @@ local function ensure_window(cfg)
 			border = cfg.ui.float.border,
 			title = LOG_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
-			footer = cfg.ui.float.footer and LOG_FLOAT_FOOTER or nil,
+			footer = cfg.ui.float.footer and log_float_footer(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil

--- a/lua/gitflow/panels/log.lua
+++ b/lua/gitflow/panels/log.lua
@@ -4,6 +4,7 @@ local git_log = require("gitflow.git.log")
 local git_branch = require("gitflow.git.branch")
 local icons = require("gitflow.icons")
 local ui_render = require("gitflow.ui.render")
+local config = require("gitflow.config")
 
 ---@class GitflowLogPanelOpts
 ---@field on_open_commit fun(commit_sha: string)|nil
@@ -74,15 +75,21 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "<CR>", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "log", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("open_commit", "<CR>"), function()
 		M.open_commit_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/prs.lua
+++ b/lua/gitflow/panels/prs.lua
@@ -27,9 +27,19 @@ local config = require("gitflow.config")
 local M = {}
 local PRS_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_prs_hl")
 local PRS_FLOAT_TITLE = "Gitflow Pull Requests"
-local PRS_FLOAT_FOOTER =
-	"<CR> view  c create  C comment  L labels  A assign  m merge"
-	.. "  o checkout  v review  r refresh  b back  q close"
+local PRS_FLOAT_FOOTER_HINTS = {
+	{ action = "view", default = "<CR>", label = "view" },
+	{ action = "create", default = "c", label = "create" },
+	{ action = "comment", default = "C", label = "comment" },
+	{ action = "labels", default = "L", label = "labels" },
+	{ action = "assign", default = "A", label = "assign" },
+	{ action = "merge", default = "m", label = "merge" },
+	{ action = "checkout", default = "o", label = "checkout" },
+	{ action = "review", default = "v", label = "review" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "back", default = "b", label = "back" },
+	{ action = "close", default = "q", label = "close" },
+}
 
 ---@type GitflowPrPanelState
 M.state = {
@@ -41,6 +51,14 @@ M.state = {
 	mode = "list",
 	active_pr_number = nil,
 }
+
+---@param cfg GitflowConfig
+---@return string
+local function prs_float_footer(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg, "prs", PRS_FLOAT_FOOTER_HINTS
+	)
+end
 
 ---@param cfg GitflowConfig
 local function ensure_window(cfg)
@@ -69,7 +87,7 @@ local function ensure_window(cfg)
 			border = cfg.ui.float.border,
 			title = PRS_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
-			footer = cfg.ui.float.footer and PRS_FLOAT_FOOTER or nil,
+			footer = cfg.ui.float.footer and prs_float_footer(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil

--- a/lua/gitflow/panels/prs.lua
+++ b/lua/gitflow/panels/prs.lua
@@ -13,6 +13,7 @@ local review_panel = require("gitflow.panels.review")
 local git_branch = require("gitflow.git.branch")
 local icons = require("gitflow.icons")
 local highlights = require("gitflow.highlights")
+local config = require("gitflow.config")
 
 ---@class GitflowPrPanelState
 ---@field bufnr integer|nil
@@ -86,39 +87,45 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "<CR>", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "prs", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("view", "<CR>"), function()
 		M.view_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
-	vim.keymap.set("n", "c", function()
+	vim.keymap.set("n", pk("create", "c"), function()
 		M.create_interactive()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "C", function()
+	vim.keymap.set("n", pk("comment", "C"), function()
 		M.comment_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "L", function()
+	vim.keymap.set("n", pk("labels", "L"), function()
 		M.edit_labels_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "A", function()
+	vim.keymap.set("n", pk("assign", "A"), function()
 		M.edit_assignees_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "m", function()
+	vim.keymap.set("n", pk("merge", "m"), function()
 		M.merge_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "o", function()
+	vim.keymap.set("n", pk("checkout", "o"), function()
 		M.checkout_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "v", function()
+	vim.keymap.set("n", pk("review", "v"), function()
 		M.review_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		if M.state.mode == "view" and M.state.active_pr_number then
 			M.open_view(M.state.active_pr_number)
 			return
@@ -126,14 +133,14 @@ local function ensure_window(cfg)
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "b", function()
+	vim.keymap.set("n", pk("back", "b"), function()
 		if M.state.mode == "view" then
 			M.state.mode = "list"
 			M.refresh()
 		end
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/prs.lua
+++ b/lua/gitflow/panels/prs.lua
@@ -40,6 +40,16 @@ local PRS_FLOAT_FOOTER_HINTS = {
 	{ action = "back", default = "b", label = "back" },
 	{ action = "close", default = "q", label = "close" },
 }
+local PRS_VIEW_HINTS = {
+	{ action = "back", default = "b", label = "back" },
+	{ action = "comment", default = "C", label = "comment" },
+	{ action = "labels", default = "L", label = "labels" },
+	{ action = "assign", default = "A", label = "assign" },
+	{ action = "merge", default = "m", label = "merge" },
+	{ action = "checkout", default = "o", label = "checkout" },
+	{ action = "review", default = "v", label = "review" },
+	{ action = "refresh", default = "r", label = "refresh" },
+}
 
 ---@type GitflowPrPanelState
 M.state = {
@@ -437,8 +447,9 @@ local function render_view(pr)
 		end
 	end
 
-	lines[#lines + 1] = "b: back to list  C: comment  L: labels  A: assign"
-		.. "  m: merge  o: checkout  v: review  r: refresh"
+	lines[#lines + 1] = ui_render.resolve_panel_key_hints(
+		M.state.cfg, "prs", PRS_VIEW_HINTS
+	)
 
 	ui.buffer.update("prs", lines)
 	M.state.line_entries = {}

--- a/lua/gitflow/panels/reset.lua
+++ b/lua/gitflow/panels/reset.lua
@@ -6,6 +6,7 @@ local git_branch = require("gitflow.git.branch")
 local icons = require("gitflow.icons")
 local ui_render = require("gitflow.ui.render")
 local status_panel = require("gitflow.panels.status")
+local config = require("gitflow.config")
 
 ---@class GitflowResetPanelState
 ---@field bufnr integer|nil
@@ -86,7 +87,13 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "<CR>", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "reset", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("select", "<CR>"), function()
 		M.select_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
@@ -96,19 +103,19 @@ local function ensure_window(cfg)
 		end, { buffer = bufnr, silent = true, nowait = true })
 	end
 
-	vim.keymap.set("n", "S", function()
+	vim.keymap.set("n", pk("soft_reset", "S"), function()
 		M.reset_under_cursor("soft")
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "H", function()
+	vim.keymap.set("n", pk("hard_reset", "H"), function()
 		M.reset_under_cursor("hard")
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/revert.lua
+++ b/lua/gitflow/panels/revert.lua
@@ -7,6 +7,7 @@ local git_conflict = require("gitflow.git.conflict")
 local icons = require("gitflow.icons")
 local ui_render = require("gitflow.ui.render")
 local status_panel = require("gitflow.panels.status")
+local config = require("gitflow.config")
 
 ---@class GitflowRevertPanelState
 ---@field bufnr integer|nil
@@ -95,7 +96,13 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "<CR>", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "revert", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("select", "<CR>"), function()
 		M.select_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
@@ -105,11 +112,11 @@ local function ensure_window(cfg)
 		end, { buffer = bufnr, silent = true, nowait = true })
 	end
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/review.lua
+++ b/lua/gitflow/panels/review.lua
@@ -61,11 +61,30 @@ local config = require("gitflow.config")
 
 local M = {}
 local REVIEW_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_review_hl")
-local REVIEW_FLOAT_FOOTER =
-	"]f/[f files  ]c/[c hunks  c comment  S submit"
-	.. "  a approve  x changes  R reply"
-	.. "  <leader>t toggle  <leader>i inline"
-	.. "  <leader>b back  r refresh  q close"
+local REVIEW_FLOAT_FOOTER_HINTS = {
+	{ action = "next_file", default = "]f", label = "next file" },
+	{ action = "prev_file", default = "[f", label = "prev file" },
+	{ action = "next_hunk", default = "]c", label = "next hunk" },
+	{ action = "prev_hunk", default = "[c", label = "prev hunk" },
+	{ action = "inline_comment", default = "c", label = "comment" },
+	{ action = "submit_review", default = "S", label = "submit" },
+	{ action = "approve", default = "a", label = "approve" },
+	{ action = "request_changes", default = "x", label = "changes" },
+	{ action = "reply", default = "R", label = "reply" },
+	{ action = "toggle_thread", default = "<leader>t", label = "toggle" },
+	{ action = "toggle_inline", default = "<leader>i", label = "inline" },
+	{ action = "back_to_pr", default = "<leader>b", label = "back" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "close", default = "q", label = "close" },
+}
+
+---@param cfg GitflowConfig
+---@return string
+local function review_float_footer(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg, "review", REVIEW_FLOAT_FOOTER_HINTS
+	)
+end
 
 ---@param line string
 ---@return boolean
@@ -153,7 +172,7 @@ local function ensure_window(cfg)
 		border = cfg.ui.float.border,
 		title = title,
 		title_pos = cfg.ui.float.title_pos,
-		footer = cfg.ui.float.footer and REVIEW_FLOAT_FOOTER or nil,
+		footer = cfg.ui.float.footer and review_float_footer(cfg) or nil,
 		footer_pos = cfg.ui.float.footer_pos,
 		on_close = function()
 			M.state.winid = nil

--- a/lua/gitflow/panels/review.lua
+++ b/lua/gitflow/panels/review.lua
@@ -5,6 +5,7 @@ local ui_render = require("gitflow.ui.render")
 local gh_prs = require("gitflow.gh.prs")
 local icons = require("gitflow.icons")
 local git_diff = require("gitflow.git.diff")
+local config = require("gitflow.config")
 
 ---@class GitflowPrReviewDraftThread
 ---@field id integer
@@ -160,67 +161,85 @@ local function ensure_window(cfg)
 	})
 
 	-- ]c/[c for hunk nav per spec
-	vim.keymap.set("n", "]f", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "review", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("next_file", "]f"), function()
 		M.next_file()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "[f", function()
+	vim.keymap.set("n", pk("prev_file", "[f"), function()
 		M.prev_file()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "]c", function()
+	vim.keymap.set("n", pk("next_hunk", "]c"), function()
 		M.next_hunk()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "[c", function()
+	vim.keymap.set("n", pk("prev_hunk", "[c"), function()
 		M.prev_hunk()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "a", function()
+	vim.keymap.set("n", pk("approve", "a"), function()
 		M.review_approve()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "x", function()
+	vim.keymap.set("n", pk("request_changes", "x"), function()
 		M.review_request_changes()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
 	-- c = inline comment per spec, S = submit review
-	vim.keymap.set("n", "c", function()
-		M.inline_comment()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"n", pk("inline_comment", "c"), function()
+			M.inline_comment()
+		end, { buffer = bufnr, silent = true, nowait = true }
+	)
 
-	vim.keymap.set("n", "S", function()
-		M.submit_pending_review()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"n", pk("submit_review", "S"), function()
+			M.submit_pending_review()
+		end, { buffer = bufnr, silent = true, nowait = true }
+	)
 
 	-- visual mode c for multi-line inline comments
-	vim.keymap.set("v", "c", function()
-		M.inline_comment_visual()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"v", pk("inline_comment_visual", "c"), function()
+			M.inline_comment_visual()
+		end, { buffer = bufnr, silent = true, nowait = true }
+	)
 
-	vim.keymap.set("n", "R", function()
+	vim.keymap.set("n", pk("reply", "R"), function()
 		M.reply_to_thread()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
 	-- F1: use <leader>t instead of t to avoid shadowing vim motion
-	vim.keymap.set("n", "<leader>t", function()
-		M.toggle_thread()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"n", pk("toggle_thread", "<leader>t"), function()
+			M.toggle_thread()
+		end, { buffer = bufnr, silent = true, nowait = true }
+	)
 
-	vim.keymap.set("n", "<leader>i", function()
-		M.toggle_inline_comments()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"n", pk("toggle_inline", "<leader>i"), function()
+			M.toggle_inline_comments()
+		end, { buffer = bufnr, silent = true, nowait = true }
+	)
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
 	-- F1: use <leader>b instead of b to avoid shadowing vim motion
-	vim.keymap.set("n", "<leader>b", function()
-		M.back_to_pr()
-	end, { buffer = bufnr, silent = true, nowait = true })
+	vim.keymap.set(
+		"n", pk("back_to_pr", "<leader>b"), function()
+			M.back_to_pr()
+		end, { buffer = bufnr, silent = true, nowait = true }
+	)
 
-	vim.keymap.set("n", "q", function()
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close_with_guard()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/stash.lua
+++ b/lua/gitflow/panels/stash.lua
@@ -5,6 +5,7 @@ local git_stash = require("gitflow.git.stash")
 local git_branch = require("gitflow.git.branch")
 local status_panel = require("gitflow.panels.status")
 local ui_render = require("gitflow.ui.render")
+local config = require("gitflow.config")
 
 ---@class GitflowStashPanelState
 ---@field bufnr integer|nil
@@ -76,23 +77,29 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "P", function()
+	local pk = function(action, default)
+		return config.resolve_panel_key(
+			cfg, "stash", action, default
+		)
+	end
+
+	vim.keymap.set("n", pk("pop", "P"), function()
 		M.pop_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "D", function()
+	vim.keymap.set("n", pk("drop", "D"), function()
 		M.drop_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "S", function()
+	vim.keymap.set("n", pk("stash", "S"), function()
 		M.push_with_prompt()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "r", function()
+	vim.keymap.set("n", pk("refresh", "r"), function()
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	vim.keymap.set("n", pk("close", "q"), function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/panels/stash.lua
+++ b/lua/gitflow/panels/stash.lua
@@ -16,7 +16,13 @@ local config = require("gitflow.config")
 local M = {}
 local STASH_FLOAT_TITLE = "Gitflow Stash"
 local STASH_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_stash_hl")
-local STASH_FLOAT_FOOTER = "P pop  D drop  S stash  r refresh  q close"
+local STASH_FLOAT_FOOTER_HINTS = {
+	{ action = "pop", default = "P", label = "pop" },
+	{ action = "drop", default = "D", label = "drop" },
+	{ action = "stash", default = "S", label = "stash" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "close", default = "q", label = "close" },
+}
 
 ---@type GitflowStashPanelState
 M.state = {
@@ -30,6 +36,14 @@ local function refresh_status_panel_if_open()
 	if status_panel.is_open() then
 		status_panel.refresh()
 	end
+end
+
+---@param cfg GitflowConfig
+---@return string
+local function stash_float_footer(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg, "stash", STASH_FLOAT_FOOTER_HINTS
+	)
 end
 
 ---@param cfg GitflowConfig
@@ -59,7 +73,7 @@ local function ensure_window(cfg)
 			border = cfg.ui.float.border,
 			title = STASH_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
-			footer = cfg.ui.float.footer and STASH_FLOAT_FOOTER or nil,
+			footer = cfg.ui.float.footer and stash_float_footer(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil

--- a/lua/gitflow/panels/status.lua
+++ b/lua/gitflow/panels/status.lua
@@ -42,9 +42,27 @@ local M = {}
 local STATUS_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_status_hl")
 local STATUS_FLOAT_TITLE = "Gitflow Status"
 local STATUS_NO_UPSTREAM_HEADER = "Outgoing / Incoming"
-local STATUS_FLOAT_FOOTER =
-	"s stage  u unstage  a stage all  A unstage all  cc commit  dd diff"
-	.. "  cx conflicts  p push  X revert  r refresh  q close"
+local STATUS_FLOAT_FOOTER_HINTS = {
+	{ action = "stage", default = "s", label = "stage" },
+	{ action = "unstage", default = "u", label = "unstage" },
+	{ action = "stage_all", default = "a", label = "stage all" },
+	{ action = "unstage_all", default = "A", label = "unstage all" },
+	{ action = "commit", default = "cc", label = "commit" },
+	{ action = "diff", default = "dd", label = "diff" },
+	{ action = "conflicts", default = "cx", label = "conflicts" },
+	{ action = "push", default = "p", label = "push" },
+	{ action = "revert", default = "X", label = "revert" },
+	{ action = "refresh", default = "r", label = "refresh" },
+	{ action = "close", default = "q", label = "close" },
+}
+
+---@param cfg GitflowConfig
+---@return string
+local function status_float_footer(cfg)
+	return ui_render.resolve_panel_key_hints(
+		cfg, "status", STATUS_FLOAT_FOOTER_HINTS
+	)
+end
 
 ---@type GitflowStatusPanelState
 M.state = {
@@ -215,7 +233,7 @@ local function ensure_window(cfg)
 			border = cfg.ui.float.border,
 			title = STATUS_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
-			footer = cfg.ui.float.footer and STATUS_FLOAT_FOOTER or nil,
+			footer = cfg.ui.float.footer and status_float_footer(cfg) or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil

--- a/lua/gitflow/panels/status.lua
+++ b/lua/gitflow/panels/status.lua
@@ -7,6 +7,7 @@ local git_status = require("gitflow.git.status")
 local git_branch = require("gitflow.git.branch")
 local conflict_panel = require("gitflow.panels.conflict")
 local icons = require("gitflow.icons")
+local config = require("gitflow.config")
 
 ---@class GitflowStatusPanelOpts
 ---@field on_commit fun()|nil
@@ -234,23 +235,28 @@ local function ensure_window(cfg)
 		})
 	end
 
-	vim.keymap.set("n", "s", function()
+	local stage_key = config.resolve_panel_key(cfg, "status", "stage", "s")
+	vim.keymap.set("n", stage_key, function()
 		M.stage_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "u", function()
+	local unstage_key = config.resolve_panel_key(cfg, "status", "unstage", "u")
+	vim.keymap.set("n", unstage_key, function()
 		M.unstage_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "a", function()
+	local stage_all_key = config.resolve_panel_key(cfg, "status", "stage_all", "a")
+	vim.keymap.set("n", stage_all_key, function()
 		M.stage_all()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "A", function()
+	local unstage_all_key = config.resolve_panel_key(cfg, "status", "unstage_all", "A")
+	vim.keymap.set("n", unstage_all_key, function()
 		M.unstage_all()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "cc", function()
+	local commit_key = config.resolve_panel_key(cfg, "status", "commit", "cc")
+	vim.keymap.set("n", commit_key, function()
 		if M.state.opts.on_commit then
 			M.state.opts.on_commit()
 		else
@@ -258,27 +264,33 @@ local function ensure_window(cfg)
 		end
 	end, { buffer = bufnr, silent = true })
 
-	vim.keymap.set("n", "dd", function()
+	local diff_key = config.resolve_panel_key(cfg, "status", "diff", "dd")
+	vim.keymap.set("n", diff_key, function()
 		M.open_diff_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
-	vim.keymap.set("n", "cx", function()
+	local conflicts_key = config.resolve_panel_key(cfg, "status", "conflicts", "cx")
+	vim.keymap.set("n", conflicts_key, function()
 		M.open_conflict_under_cursor()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "p", function()
+	local push_key = config.resolve_panel_key(cfg, "status", "push", "p")
+	vim.keymap.set("n", push_key, function()
 		M.push_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
-	vim.keymap.set("n", "X", function()
+	local revert_key = config.resolve_panel_key(cfg, "status", "revert", "X")
+	vim.keymap.set("n", revert_key, function()
 		M.revert_under_cursor()
 	end, { buffer = bufnr, silent = true })
 
-	vim.keymap.set("n", "r", function()
+	local refresh_key = config.resolve_panel_key(cfg, "status", "refresh", "r")
+	vim.keymap.set("n", refresh_key, function()
 		M.refresh()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
-	vim.keymap.set("n", "q", function()
+	local close_key = config.resolve_panel_key(cfg, "status", "close", "q")
+	vim.keymap.set("n", close_key, function()
 		M.close()
 	end, { buffer = bufnr, silent = true, nowait = true })
 end

--- a/lua/gitflow/ui/render.lua
+++ b/lua/gitflow/ui/render.lua
@@ -170,6 +170,33 @@ function M.format_key_hints(pairs)
 	return table.concat(parts, "  ")
 end
 
+---Resolve panel action keys from config and format hint pairs.
+---@param cfg GitflowConfig|nil
+---@param panel string
+---@param pairs table[]  list of { action, default, label }
+---@return string
+function M.resolve_panel_key_hints(cfg, panel, pairs)
+	local key_config = require("gitflow.config")
+	local resolved_cfg = cfg or key_config.current
+	local resolved_pairs = {}
+
+	for _, pair in ipairs(pairs or {}) do
+		local action = pair.action or pair[1]
+		local default = pair.default or pair[2]
+		local label = pair.label or pair[3]
+		if action and default and label then
+			resolved_pairs[#resolved_pairs + 1] = {
+				key = key_config.resolve_panel_key(
+					resolved_cfg, panel, action, default
+				),
+				action = label,
+			}
+		end
+	end
+
+	return M.format_key_hints(resolved_pairs)
+end
+
 ---Apply standard panel highlights to a buffer after rendering.
 ---Applies GitflowTitle to line 0 only when the first line is an inline
 ---header title, then scans separators and footer metadata lines.

--- a/scripts/test_panel_keybindings.lua
+++ b/scripts/test_panel_keybindings.lua
@@ -1,0 +1,392 @@
+-- scripts/test_panel_keybindings.lua — panel-local keybinding customization
+--
+-- Run: nvim --headless -u NONE -l scripts/test_panel_keybindings.lua
+--
+-- Covers:
+--   1. Config validation for panel_keybindings
+--   2. Conflict detection within a panel
+--   3. Fallback to defaults when no overrides
+--   4. Override resolution via resolve_panel_key
+--   5. E2E: overridden key works on a status panel buffer
+
+vim.opt.runtimepath:append(".")
+
+local pass_count = 0
+local fail_count = 0
+local test_names = {}
+
+local function assert_true(condition, message)
+	if not condition then
+		fail_count = fail_count + 1
+		table.insert(test_names, "FAIL: " .. message)
+		io.write("  FAIL: " .. message .. "\n")
+	else
+		pass_count = pass_count + 1
+		table.insert(test_names, "PASS: " .. message)
+		io.write("  PASS: " .. message .. "\n")
+	end
+end
+
+local function assert_equals(actual, expected, message)
+	if actual ~= expected then
+		fail_count = fail_count + 1
+		local err = ("%s (expected=%s, actual=%s)"):format(
+			message,
+			vim.inspect(expected),
+			vim.inspect(actual)
+		)
+		table.insert(test_names, "FAIL: " .. err)
+		io.write("  FAIL: " .. err .. "\n")
+	else
+		pass_count = pass_count + 1
+		table.insert(test_names, "PASS: " .. message)
+		io.write("  PASS: " .. message .. "\n")
+	end
+end
+
+local function assert_error(fn, pattern, message)
+	local ok, err = pcall(fn)
+	if ok then
+		fail_count = fail_count + 1
+		table.insert(test_names, "FAIL: " .. message .. " (no error)")
+		io.write("  FAIL: " .. message .. " (no error thrown)\n")
+	elseif pattern and not tostring(err):find(pattern, 1, true) then
+		fail_count = fail_count + 1
+		local detail = message
+			.. " (error did not match pattern '"
+			.. pattern .. "'): " .. tostring(err)
+		table.insert(test_names, "FAIL: " .. detail)
+		io.write("  FAIL: " .. detail .. "\n")
+	else
+		pass_count = pass_count + 1
+		table.insert(test_names, "PASS: " .. message)
+		io.write("  PASS: " .. message .. "\n")
+	end
+end
+
+-- ── Test 1: Default setup with empty panel_keybindings ──────────────
+io.write("\n[1] Default panel_keybindings\n")
+
+local gitflow = require("gitflow")
+local cfg = gitflow.setup({})
+
+assert_equals(
+	type(cfg.panel_keybindings), "table",
+	"panel_keybindings should default to a table"
+)
+assert_equals(
+	next(cfg.panel_keybindings), nil,
+	"panel_keybindings should default to empty"
+)
+
+-- ── Test 2: resolve_panel_key fallback ──────────────────────────────
+io.write("\n[2] resolve_panel_key fallback to default\n")
+
+local config = require("gitflow.config")
+
+assert_equals(
+	config.resolve_panel_key(cfg, "status", "stage", "s"),
+	"s",
+	"should return default when no override exists"
+)
+assert_equals(
+	config.resolve_panel_key(cfg, "branch", "create", "c"),
+	"c",
+	"should return default for branch panel"
+)
+
+-- ── Test 3: resolve_panel_key with override ─────────────────────────
+io.write("\n[3] resolve_panel_key with override\n")
+
+local cfg_override = gitflow.setup({
+	panel_keybindings = {
+		status = {
+			stage = "S",
+			unstage = "U",
+		},
+	},
+})
+
+assert_equals(
+	config.resolve_panel_key(cfg_override, "status", "stage", "s"),
+	"S",
+	"should return override key for stage"
+)
+assert_equals(
+	config.resolve_panel_key(cfg_override, "status", "unstage", "u"),
+	"U",
+	"should return override key for unstage"
+)
+assert_equals(
+	config.resolve_panel_key(cfg_override, "status", "close", "q"),
+	"q",
+	"should return default for non-overridden action"
+)
+assert_equals(
+	config.resolve_panel_key(cfg_override, "branch", "create", "c"),
+	"c",
+	"should return default for non-overridden panel"
+)
+
+-- ── Test 4: Validation — invalid panel name ─────────────────────────
+io.write("\n[4] Validation: invalid panel name\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			bogus_panel = { stage = "s" },
+		},
+	})
+end, "not a valid panel name",
+	"should reject unknown panel name")
+
+-- ── Test 5: Validation — non-table panel value ──────────────────────
+io.write("\n[5] Validation: non-table panel value\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			status = "not a table",
+		},
+	})
+end, "must be a table",
+	"should reject non-table panel override")
+
+-- ── Test 6: Validation — non-string action name ─────────────────────
+io.write("\n[6] Validation: non-string action name\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			status = { [123] = "x" },
+		},
+	})
+end, "non-empty strings",
+	"should reject non-string action key")
+
+-- ── Test 7: Validation — non-string mapping value ───────────────────
+io.write("\n[7] Validation: non-string mapping value\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			status = { stage = 42 },
+		},
+	})
+end, "non-empty string",
+	"should reject non-string mapping value")
+
+-- ── Test 8: Validation — empty string action ────────────────────────
+io.write("\n[8] Validation: empty string action\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			status = { [""] = "x" },
+		},
+	})
+end, "non-empty strings",
+	"should reject empty action key")
+
+-- ── Test 9: Validation — empty string mapping ───────────────────────
+io.write("\n[9] Validation: empty string mapping\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			status = { stage = "" },
+		},
+	})
+end, "non-empty string",
+	"should reject empty mapping value")
+
+-- ── Test 10: Conflict detection ─────────────────────────────────────
+io.write("\n[10] Conflict detection within a panel\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			status = {
+				stage = "x",
+				unstage = "x",
+			},
+		},
+	})
+end, "conflicting key",
+	"should reject duplicate keys in same panel")
+
+-- ── Test 11: Non-table panel_keybindings ────────────────────────────
+io.write("\n[11] Validation: non-table panel_keybindings\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = "invalid",
+	})
+end, "must be a table",
+	"should reject non-table panel_keybindings")
+
+-- ── Test 12: Valid panel names accepted ─────────────────────────────
+io.write("\n[12] All valid panel names accepted\n")
+
+local valid_panels = {
+	"status", "branch", "diff", "review", "conflict",
+	"issues", "prs", "log", "stash", "reset",
+	"revert", "cherry_pick",
+}
+
+for _, panel in ipairs(valid_panels) do
+	local ok = pcall(function()
+		gitflow.setup({
+			panel_keybindings = {
+				[panel] = { close = "Q" },
+			},
+		})
+	end)
+	assert_true(ok, "panel name '" .. panel .. "' should be valid")
+end
+
+-- ── Test 13: E2E — overridden key works on status buffer ────────────
+io.write("\n[13] E2E: overridden status panel keybinding\n")
+
+local e2e_cfg = gitflow.setup({
+	ui = {
+		default_layout = "split",
+		split = { orientation = "vertical", size = 40 },
+	},
+	panel_keybindings = {
+		status = {
+			stage = "S",
+			close = "Q",
+		},
+	},
+})
+
+-- Stub git/gh to prevent real calls
+local utils = require("gitflow.utils")
+local orig_system = utils.system
+utils.system = function(cmd, opts)
+	if type(cmd) == "table" then
+		local sub = cmd[1] or ""
+		if sub == "git" then
+			local arg2 = cmd[2] or ""
+			if arg2 == "status" then
+				if opts and opts.on_exit then
+					opts.on_exit("", 0)
+				end
+				return
+			elseif arg2 == "rev-parse" then
+				if opts and opts.on_exit then
+					opts.on_exit(vim.fn.getcwd(), 0)
+				end
+				return
+			elseif arg2 == "branch" then
+				if opts and opts.on_exit then
+					opts.on_exit("* main", 0)
+				end
+				return
+			elseif arg2 == "log" then
+				if opts and opts.on_exit then
+					opts.on_exit("", 0)
+				end
+				return
+			elseif arg2 == "diff" then
+				if opts and opts.on_exit then
+					opts.on_exit("", 0)
+				end
+				return
+			end
+		elseif sub == "gh" then
+			if opts and opts.on_exit then
+				opts.on_exit("", 0)
+			end
+			return
+		end
+	end
+	if opts and opts.on_exit then
+		opts.on_exit("", 0)
+	end
+end
+
+local status_panel = require("gitflow.panels.status")
+local ui = require("gitflow.ui")
+
+-- Open the status panel
+status_panel.open(e2e_cfg)
+vim.wait(200, function() return false end)
+
+local bufnr = status_panel.state.bufnr
+
+local function find_buf_map(buf, mode, lhs)
+	local maps = vim.api.nvim_buf_get_keymap(buf, mode)
+	local target = vim.api.nvim_replace_termcodes(lhs, true, true, true)
+	for _, m in ipairs(maps) do
+		local mlhs = vim.api.nvim_replace_termcodes(
+			m.lhs, true, true, true
+		)
+		if mlhs == target then
+			return m
+		end
+	end
+	return nil
+end
+
+if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+	-- The overridden key "S" should be mapped (for stage)
+	local s_map = find_buf_map(bufnr, "n", "S")
+	assert_true(
+		s_map ~= nil,
+		"overridden key 'S' should be mapped on status buffer"
+	)
+
+	-- The default key "s" should NOT be mapped
+	local old_s_map = find_buf_map(bufnr, "n", "s")
+	assert_true(
+		old_s_map == nil,
+		"default key 's' should NOT be mapped when overridden"
+	)
+
+	-- The overridden close key "Q" should be mapped
+	local q_map = find_buf_map(bufnr, "n", "Q")
+	assert_true(
+		q_map ~= nil,
+		"overridden key 'Q' should be mapped for close"
+	)
+
+	-- The default close key "q" should NOT be mapped
+	local old_q = find_buf_map(bufnr, "n", "q")
+	assert_true(
+		old_q == nil,
+		"default key 'q' should NOT be mapped when overridden"
+	)
+
+	-- Non-overridden keys should still work
+	local refresh_map = find_buf_map(bufnr, "n", "r")
+	assert_true(
+		refresh_map ~= nil,
+		"non-overridden key 'r' (refresh) should still be mapped"
+	)
+else
+	assert_true(false, "status panel buffer should be valid")
+	assert_true(false, "skip: buffer not valid")
+	assert_true(false, "skip: buffer not valid")
+	assert_true(false, "skip: buffer not valid")
+	assert_true(false, "skip: buffer not valid")
+end
+
+-- Cleanup
+status_panel.close()
+utils.system = orig_system
+
+-- ── Summary ─────────────────────────────────────────────────────────
+io.write(("\n%d passed, %d failed\n"):format(pass_count, fail_count))
+if fail_count > 0 then
+	io.write("\nFailed tests:\n")
+	for _, name in ipairs(test_names) do
+		if name:find("^FAIL") then
+			io.write("  " .. name .. "\n")
+		end
+	end
+	vim.cmd("cquit! 1")
+else
+	vim.cmd("quit!")
+end

--- a/scripts/test_panel_keybindings.lua
+++ b/scripts/test_panel_keybindings.lua
@@ -215,8 +215,37 @@ assert_error(function()
 end, "conflicting key",
 	"should reject duplicate keys in same panel")
 
--- ── Test 11: Non-table panel_keybindings ────────────────────────────
-io.write("\n[11] Validation: non-table panel_keybindings\n")
+-- ── Test 11: Conflict detection with existing defaults ──────────────
+io.write("\n[11] Conflict detection against default keymaps\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			status = {
+				stage = "u",
+			},
+		},
+	})
+end, "conflicting key",
+	"should reject override that collides with non-overridden default")
+
+local ok_no_conflict = pcall(function()
+	gitflow.setup({
+		panel_keybindings = {
+			status = {
+				stage = "u",
+				unstage = "U",
+			},
+		},
+	})
+end)
+assert_true(
+	ok_no_conflict,
+	"should allow overrides when all resulting panel keys are unique"
+)
+
+-- ── Test 12: Non-table panel_keybindings ────────────────────────────
+io.write("\n[12] Validation: non-table panel_keybindings\n")
 
 assert_error(function()
 	gitflow.setup({
@@ -225,8 +254,8 @@ assert_error(function()
 end, "must be a table",
 	"should reject non-table panel_keybindings")
 
--- ── Test 12: Valid panel names accepted ─────────────────────────────
-io.write("\n[12] All valid panel names accepted\n")
+-- ── Test 13: Valid panel names accepted ─────────────────────────────
+io.write("\n[13] All valid panel names accepted\n")
 
 local valid_panels = {
 	"status", "branch", "diff", "review", "conflict",
@@ -245,8 +274,8 @@ for _, panel in ipairs(valid_panels) do
 	assert_true(ok, "panel name '" .. panel .. "' should be valid")
 end
 
--- ── Test 13: E2E — overridden key works on status buffer ────────────
-io.write("\n[13] E2E: overridden status panel keybinding\n")
+-- ── Test 14: E2E — overridden key works on status buffer ────────────
+io.write("\n[14] E2E: overridden status panel keybinding\n")
 
 local e2e_cfg = gitflow.setup({
 	ui = {

--- a/scripts/test_panel_keybindings.lua
+++ b/scripts/test_panel_keybindings.lua
@@ -343,6 +343,62 @@ assert_error(function()
 end, "conflicting key",
 	"should reject quick-select key collisions with list keys")
 
+-- ── Test 12b: Reserve positional shortcuts for commit-select panels ──
+io.write("\n[12b] Validation: reserved positional shortcuts\n")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			reset = {
+				close = "1",
+			},
+		},
+	})
+end, "reserved positional key",
+	"should reject reset overrides that collide with fixed 1-9 shortcuts")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			revert = {
+				refresh = "2",
+			},
+		},
+	})
+end, "reserved positional key",
+	"should reject revert overrides that collide with fixed 1-9 shortcuts")
+
+assert_error(function()
+	gitflow.setup({
+		panel_keybindings = {
+			cherry_pick = {
+				close = "9",
+			},
+		},
+	})
+end, "reserved positional key",
+	"should reject cherry-pick overrides that collide with fixed 1-9 shortcuts")
+
+local ok_no_positional_conflict = pcall(function()
+	gitflow.setup({
+		panel_keybindings = {
+			reset = {
+				close = "Q",
+			},
+			revert = {
+				refresh = "R",
+			},
+			cherry_pick = {
+				close = "C",
+			},
+		},
+	})
+end)
+assert_true(
+	ok_no_positional_conflict,
+	"should allow non-positional overrides for reset/revert/cherry_pick"
+)
+
 -- ── Test 13: Non-table panel_keybindings ────────────────────────────
 io.write("\n[13] Validation: non-table panel_keybindings\n")
 

--- a/scripts/test_panel_keybindings.lua
+++ b/scripts/test_panel_keybindings.lua
@@ -742,6 +742,56 @@ end
 
 palette_panel.close()
 
+-- ── Test 19: E2E — stash float footer reflects overrides ─────────────
+io.write("\n[19] E2E: stash float footer uses overridden keys\n")
+
+local stash_cfg = gitflow.setup({
+	panel_keybindings = {
+		stash = {
+			pop = "X",
+			close = "Q",
+		},
+	},
+})
+
+local stash_panel = require("gitflow.panels.stash")
+local git_stash = require("gitflow.git.stash")
+local git_branch = require("gitflow.git.branch")
+local orig_stash_list = git_stash.list
+local orig_branch_current = git_branch.current
+
+git_stash.list = function(_, cb)
+	cb(nil, {})
+end
+git_branch.current = function(_, cb)
+	cb(nil, "main")
+end
+
+stash_panel.open(stash_cfg)
+vim.wait(200, function() return false end)
+
+local stash_footer = window_footer_text(stash_panel.state.winid)
+assert_true(
+	stash_footer:find("X pop", 1, true) ~= nil,
+	"stash footer should show overridden pop key"
+)
+assert_true(
+	stash_footer:find("Q close", 1, true) ~= nil,
+	"stash footer should show overridden close key"
+)
+assert_true(
+	stash_footer:find("P pop", 1, true) == nil,
+	"stash footer should not show default pop key after override"
+)
+assert_true(
+	stash_footer:find("q close", 1, true) == nil,
+	"stash footer should not show default close key after override"
+)
+
+stash_panel.close()
+git_stash.list = orig_stash_list
+git_branch.current = orig_branch_current
+
 -- ── Summary ─────────────────────────────────────────────────────────
 io.write(("\n%d passed, %d failed\n"):format(pass_count, fail_count))
 if fail_count > 0 then


### PR DESCRIPTION
Closes #307

## Summary

- **What changed**: Added a `config.panel_keybindings` section that allows users
  to override per-panel buffer-local keymaps through configuration. All 12 panels
  (status, branch, diff, review, conflict, issues, prs, log, stash, reset, revert,
  cherry_pick) now resolve keybindings from config via `config.resolve_panel_key()`
  instead of hardcoded strings.
- **Why**: Users previously could not remap panel-local keybindings without forking
  the plugin. This was the last major customization gap.
- **Key decisions**:
  - Empty `panel_keybindings = {}` default preserves all current behavior (backward compatible).
  - Validation detects intra-panel key conflicts (same key mapped to two actions).
  - Numeric 1-9 positional shortcuts in reset/revert/cherry_pick panels are excluded
    from overrides (they are positional, not action-based).

## Testing/Installing/Reviewing

- Run new test suite:
  `nvim --headless -u NONE -l scripts/test_panel_keybindings.lua`
  (33 tests covering validation, conflict detection, fallback, and E2E override)
- Run existing suites to verify no regressions:
  `for t in $(ls scripts/test_stage*.lua | sort); do nvim --headless -u NONE -l "$t"; done`
  `for t in $(ls tests/e2e/*.lua | sort); do nvim --headless -u tests/minimal_init.lua -l "$t"; done`
- Example configuration:
  ```lua
  require("gitflow").setup({
    panel_keybindings = {
      status = { stage = "S", unstage = "U" },
      branch = { create = "n" },
    },
  })
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)