### PR TITLE
Fix default keymaps, GitflowSign* highlights, and <leader>gr collision

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -26,7 +26,7 @@ Normal-mode mappings available in any buffer. Configured via
 | `gX` | Stash pop | `stash_pop` |
 | `<leader>gb` | Open branch list | `branch` |
 | `<leader>gi` | Open issue list | `issue` |
-| `<leader>gr` | Open PR list | `pr` |
+| `<leader>gR` | Open PR list | `pr` |
 | `<leader>gL` | Open label list | `label` |
 | `gR` | Open reset panel | `reset` |
 | `<leader>gm` | Open conflict panel | `conflict` |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ require("gitflow").setup({
     stash_pop  = "gX",
     branch     = "<leader>gb",
     issue      = "<leader>gi",
-    pr         = "<leader>gr",
+    pr         = "<leader>gR",
     label      = "<leader>gL",
     conflict   = "<leader>gm",
     palette    = "<leader>gp",
@@ -240,7 +240,7 @@ instructions.
 | `gX` | Stash pop |
 | `<leader>gb` | Branch list |
 | `<leader>gi` | Issues |
-| `<leader>gr` | Pull requests |
+| `<leader>gR` | Pull requests |
 | `<leader>gL` | Labels |
 | `<leader>gm` | Conflicts |
 | `<leader>gp` | Command palette |

--- a/doc/gitflow.txt
+++ b/doc/gitflow.txt
@@ -105,7 +105,7 @@ Default keybindings:
     stash_pop       gX                  <Plug>(GitflowStashPop)
     branch          <leader>gb          <Plug>(GitflowBranch)
     issue           <leader>gi          <Plug>(GitflowIssue)
-    pr              <leader>gr          <Plug>(GitflowPr)
+    pr              <leader>gR          <Plug>(GitflowPr)
     label           <leader>gL          <Plug>(GitflowLabel)
     conflict        <leader>gm          <Plug>(GitflowConflicts)
     palette         <leader>gp          <Plug>(GitflowPalette)

--- a/lua/gitflow/config.lua
+++ b/lua/gitflow/config.lua
@@ -69,13 +69,17 @@ local M = {}
 function M.defaults()
 	return {
 		keybindings = {
+			-- Documented defaults — must match README.md, KEYBINDINGS.md, and
+			-- doc/gitflow.txt. Every entry here is also exercised by
+			-- scripts/test_keybinding_docs.lua.
 			help = "<leader>gh",
-			refresh = "<leader>gg",
+			open = "<leader>go",
+			refresh = "<leader>gr",
 			close = "<leader>gq",
 			status = "gs",
 			commit = "gc",
-			push = "<leader>gP",
-			pull = "<leader>gp",
+			push = "gp",
+			pull = "gP",
 			fetch = "<leader>gf",
 			diff = "gd",
 			log = "gl",
@@ -84,17 +88,21 @@ function M.defaults()
 			stash_pop = "gX",
 			branch = "<leader>gb",
 			issue = "<leader>gi",
-			pr = "<leader>gr",
+			-- pr uses <leader>gR (capital) to avoid colliding with refresh
+			-- on <leader>gr. `gR` without leader is reset — distinct chord.
+			pr = "<leader>gR",
+			label = "<leader>gL",
+			conflict = "<leader>gm",
+			palette = "<leader>gp",
 			reset = "gR",
+			-- Additional actions for panels that pre-date their own doc entries.
 			revert = "gV",
 			tag = "gT",
 			blame = "gB",
 			reflog = "gF",
 			cherry_pick = "gC",
 			rebase_interactive = "gI",
-			conflict = "<leader>gm",
 			actions = "gA",
-			palette = "<leader>go",
 			notifications = "gN",
 		},
 		ui = {

--- a/lua/gitflow/highlights.lua
+++ b/lua/gitflow/highlights.lua
@@ -44,6 +44,13 @@ local function build_default_groups(palette)
 		GitflowAdded = { link = "DiffAdd" },
 		GitflowRemoved = { link = "DiffDelete" },
 		GitflowModified = { link = "DiffChange" },
+		-- Sign column indicators (linked to the base groups so user overrides
+		-- via setup({ highlights = { GitflowSignAdded = ... } }) take effect —
+		-- signs.lua uses these names as texthl targets).
+		GitflowSignAdded = { link = "GitflowAdded" },
+		GitflowSignModified = { link = "GitflowModified" },
+		GitflowSignDeleted = { link = "GitflowRemoved" },
+		GitflowSignConflict = { link = "GitflowConflictLocal" },
 		-- Diff view — distinct styling for file headers, hunk headers, context
 		GitflowDiffFileHeader = { fg = palette.diff_file_header, bold = true },
 		GitflowDiffHunkHeader = { fg = palette.diff_hunk_header, bold = true },

--- a/lua/gitflow/signs.lua
+++ b/lua/gitflow/signs.lua
@@ -11,22 +11,22 @@ M.extmark_namespace = EXTMARK_NAMESPACE
 local SIGN_TYPES = {
 	added = {
 		name = "GitflowSignAdded",
-		hl = "GitflowAdded",
+		hl = "GitflowSignAdded",
 		config_key = "added",
 	},
 	modified = {
 		name = "GitflowSignModified",
-		hl = "GitflowModified",
+		hl = "GitflowSignModified",
 		config_key = "modified",
 	},
 	deleted = {
 		name = "GitflowSignDeleted",
-		hl = "GitflowRemoved",
+		hl = "GitflowSignDeleted",
 		config_key = "deleted",
 	},
 	conflict = {
 		name = "GitflowSignConflict",
-		hl = "GitflowConflictLocal",
+		hl = "GitflowSignConflict",
 		config_key = "conflict",
 	},
 }

--- a/scripts/test_keybinding_docs.lua
+++ b/scripts/test_keybinding_docs.lua
@@ -37,154 +37,339 @@ local gitflow = require("gitflow")
 local cfg = gitflow.setup({})
 local defaults = cfg.keybindings
 
--- Read KEYBINDINGS.md and extract the global table entries
+-- Parse the Global keybinding table out of KEYBINDINGS.md.
+-- Row format: | `<key>` | <action> | `<config_key>` |
 local root = vim.fn.fnamemodify(".", ":p")
-local doc_path = root .. "KEYBINDINGS.md"
-local lines = vim.fn.readfile(doc_path)
-assert_true(#lines > 0, "KEYBINDINGS.md should exist")
-
--- Parse global keybinding table rows:
--- | `<key>` | <action> | `<config_key>` |
-local doc_entries = {}
-local in_global = false
-for _, line in ipairs(lines) do
-	if line:find("## Global", 1, true) then
-		in_global = true
-	elseif line:match("^## ") and in_global then
-		break
-	end
-	if in_global then
-		local key, config_key = line:match(
-			"^| `([^`]+)` |[^|]+| `([^`]+)` |$"
-		)
-		if key and config_key then
-			doc_entries[config_key] = key
+local function parse_keybindings_md()
+	local lines = vim.fn.readfile(root .. "KEYBINDINGS.md")
+	assert_true(#lines > 0, "KEYBINDINGS.md should exist")
+	local entries = {}
+	local in_global = false
+	for _, line in ipairs(lines) do
+		if line:find("## Global", 1, true) then
+			in_global = true
+		elseif line:match("^## ") and in_global then
+			break
+		end
+		if in_global then
+			local key, cfg_key = line:match(
+				"^| `([^`]+)` |[^|]+| `([^`]+)` |$"
+			)
+			if key and cfg_key then
+				entries[cfg_key] = key
+			end
 		end
 	end
+	return entries
 end
 
-test(
-	"KEYBINDINGS.md global table has entries",
-	function()
-		local count = 0
-		for _ in pairs(doc_entries) do
-			count = count + 1
+-- Parse the Global Mappings table out of README.md.
+-- Row format: | `<key>` | <action label> |
+local function parse_readme_global_mappings()
+	local lines = vim.fn.readfile(root .. "README.md")
+	assert_true(#lines > 0, "README.md should exist")
+	local entries = {}
+	local in_section = false
+	for _, line in ipairs(lines) do
+		if line:find("### Global Mappings", 1, true) then
+			in_section = true
+		elseif in_section and line:match("^##%s") then
+			break
 		end
+		if in_section then
+			local key, label = line:match("^| `([^`]+)` | ([^|]+) |$")
+			if key and label then
+				entries[#entries + 1] = {
+					key = key,
+					label = vim.trim(label),
+				}
+			end
+		end
+	end
+	return entries
+end
+
+-- Parse the Default keybindings table out of doc/gitflow.txt.
+-- Row format: "    <action>   <leader-or-key>   <Plug>(...)"
+local function parse_helptxt_defaults()
+	local lines = vim.fn.readfile(root .. "doc/gitflow.txt")
+	assert_true(#lines > 0, "doc/gitflow.txt should exist")
+	local entries = {}
+	local in_table = false
+	for _, line in ipairs(lines) do
+		if line:match("^Default keybindings:") then
+			in_table = true
+		elseif in_table and line:match("^%S") then
+			break
+		end
+		if in_table then
+			local action, key =
+				line:match("^%s+(%S+)%s+(%S+)%s+<Plug>%(Gitflow")
+			if action and key and action ~= "Action" then
+				entries[action] = key
+			end
+		end
+	end
+	return entries
+end
+
+local doc_entries = parse_keybindings_md()
+local readme_mappings = parse_readme_global_mappings()
+local helptxt_defaults = parse_helptxt_defaults()
+
+test("KEYBINDINGS.md global table parses entries", function()
+	local count = 0
+	for _ in pairs(doc_entries) do
+		count = count + 1
+	end
+	assert_true(count >= 10, "should parse multiple entries")
+end)
+
+test("README.md Global Mappings table parses entries", function()
+	assert_true(#readme_mappings >= 10, "should parse multiple entries")
+end)
+
+test("doc/gitflow.txt default table parses entries", function()
+	local count = 0
+	for _ in pairs(helptxt_defaults) do
+		count = count + 1
+	end
+	assert_true(count >= 10, "should parse multiple entries")
+end)
+
+-- Every config_key in KEYBINDINGS.md's Global table must match config defaults.
+-- This is the regression gate for the QA DEFECT-001 class of bugs where the
+-- defaults-table silently drifts from the documented contract.
+test(
+	"every KEYBINDINGS.md entry matches config.defaults()",
+	function()
+		for cfg_key, doc_key in pairs(doc_entries) do
+			assert_true(
+				defaults[cfg_key] ~= nil,
+				("defaults.%s should exist"):format(cfg_key)
+			)
+			assert_equals(
+				defaults[cfg_key],
+				doc_key,
+				("KEYBINDINGS.md vs defaults[%s]"):format(cfg_key)
+			)
+		end
+	end
+)
+
+-- Every action in doc/gitflow.txt must match config defaults too.
+test(
+	"every doc/gitflow.txt entry matches config.defaults()",
+	function()
+		for action, help_key in pairs(helptxt_defaults) do
+			assert_true(
+				defaults[action] ~= nil,
+				("defaults.%s should exist"):format(action)
+			)
+			assert_equals(
+				defaults[action],
+				help_key,
+				("doc/gitflow.txt vs defaults[%s]"):format(action)
+			)
+		end
+	end
+)
+
+-- KEYBINDINGS.md and doc/gitflow.txt must agree with each other.
+test(
+	"KEYBINDINGS.md and doc/gitflow.txt agree on default keys",
+	function()
+		for cfg_key, doc_key in pairs(doc_entries) do
+			if helptxt_defaults[cfg_key] then
+				assert_equals(
+					helptxt_defaults[cfg_key],
+					doc_key,
+					("doc mismatch for %s"):format(cfg_key)
+				)
+			end
+		end
+	end
+)
+
+-- Every key listed in the README Global Mappings table must also be the
+-- runtime default for exactly one action (i.e. the plugin actually installs
+-- that mapping). This catches the class of bug where docs show a key the
+-- setup code does not wire up.
+test(
+	"every README Global Mappings key is installed by setup()",
+	function()
+		local installed = {}
+		for _, key in pairs(defaults) do
+			installed[key] = true
+		end
+		for _, row in ipairs(readme_mappings) do
+			assert_true(
+				installed[row.key],
+				("README lists %q (%s) but setup() does not install it")
+					:format(row.key, row.label)
+			)
+		end
+	end
+)
+
+-- No two documented default actions may collide on the same key. DEFECT-003
+-- fell out of `<leader>gr` being assigned to both refresh and pr; this test
+-- locks the resolution in.
+test("no two default keybindings collide on the same key", function()
+	local seen = {}
+	for cfg_key, doc_key in pairs(doc_entries) do
+		if seen[doc_key] then
+			error(
+				("KEYBINDINGS.md collision: %q used by both %s and %s"):format(
+					doc_key,
+					seen[doc_key],
+					cfg_key
+				),
+				0
+			)
+		end
+		seen[doc_key] = cfg_key
+	end
+end)
+
+-- Spot checks for the three specific cases called out in the QA report.
+test("push default is `gp`", function()
+	assert_equals(defaults.push, "gp", "push default")
+	assert_equals(doc_entries["push"], "gp", "KEYBINDINGS.md push")
+end)
+
+test("pull default is `gP`", function()
+	assert_equals(defaults.pull, "gP", "pull default")
+	assert_equals(doc_entries["pull"], "gP", "KEYBINDINGS.md pull")
+end)
+
+test("palette default is `<leader>gp` (not colliding with pull)", function()
+	assert_equals(defaults.palette, "<leader>gp", "palette default")
+	assert_equals(
+		doc_entries["palette"],
+		"<leader>gp",
+		"KEYBINDINGS.md palette"
+	)
+end)
+
+test("open default is `<leader>go`", function()
+	assert_equals(defaults.open, "<leader>go", "open default")
+	assert_equals(doc_entries["open"], "<leader>go", "KEYBINDINGS.md open")
+end)
+
+test("label default is `<leader>gL`", function()
+	assert_equals(defaults.label, "<leader>gL", "label default")
+	assert_equals(doc_entries["label"], "<leader>gL", "KEYBINDINGS.md label")
+end)
+
+test("refresh default is `<leader>gr` (wins the gr slot)", function()
+	assert_equals(defaults.refresh, "<leader>gr", "refresh default")
+	assert_equals(
+		doc_entries["refresh"],
+		"<leader>gr",
+		"KEYBINDINGS.md refresh"
+	)
+end)
+
+test("pr default is `<leader>gR` (resolved gr collision)", function()
+	assert_equals(defaults.pr, "<leader>gR", "pr default")
+	assert_equals(doc_entries["pr"], "<leader>gR", "KEYBINDINGS.md pr")
+end)
+
+test("pr and reset keybindings are distinct", function()
+	assert_true(
+		defaults.pr ~= defaults.reset,
+		"pr and reset must have different keys"
+	)
+	assert_true(
+		doc_entries["pr"] ~= doc_entries["reset"],
+		"pr and reset docs must show different keys"
+	)
+end)
+
+test("reset default is `gR`", function()
+	assert_equals(defaults.reset, "gR", "reset default")
+	assert_equals(doc_entries["reset"], "gR", "KEYBINDINGS.md reset")
+end)
+
+-- After setup(), the actual runtime keymaps must resolve to the expected
+-- <Plug> target. This uses maparg() the same way the test_boyz QA prober did,
+-- so DEFECT-001 is observable the same way it was caught.
+local plug_by_action = {
+	help = "<Plug>(GitflowHelp)",
+	open = "<Plug>(GitflowOpen)",
+	refresh = "<Plug>(GitflowRefresh)",
+	close = "<Plug>(GitflowClose)",
+	status = "<Plug>(GitflowStatus)",
+	branch = "<Plug>(GitflowBranch)",
+	commit = "<Plug>(GitflowCommit)",
+	push = "<Plug>(GitflowPush)",
+	pull = "<Plug>(GitflowPull)",
+	fetch = "<Plug>(GitflowFetch)",
+	diff = "<Plug>(GitflowDiff)",
+	log = "<Plug>(GitflowLog)",
+	stash = "<Plug>(GitflowStash)",
+	stash_push = "<Plug>(GitflowStashPush)",
+	stash_pop = "<Plug>(GitflowStashPop)",
+	issue = "<Plug>(GitflowIssue)",
+	pr = "<Plug>(GitflowPr)",
+	label = "<Plug>(GitflowLabel)",
+	conflict = "<Plug>(GitflowConflicts)",
+	palette = "<Plug>(GitflowPalette)",
+	reset = "<Plug>(GitflowReset)",
+}
+
+test("every documented default resolves to its <Plug> target at runtime", function()
+	local leader = vim.g.mapleader or "\\"
+	for cfg_key, expected_plug in pairs(plug_by_action) do
+		local key = doc_entries[cfg_key]
 		assert_true(
-			count > 0,
-			"should parse at least one entry"
+			key ~= nil,
+			("KEYBINDINGS.md should list a default for %s"):format(cfg_key)
 		)
-	end
-)
-
-test(
-	"issue doc entry exists",
-	function()
+		local resolved = key:gsub("<leader>", leader)
+		local m = vim.fn.maparg(resolved, "n", false, true) or {}
 		assert_true(
-			doc_entries["issue"] ~= nil,
-			"issue should be in KEYBINDINGS.md global table"
-		)
-	end
-)
-
-test(
-	"issue doc entry matches config default",
-	function()
-		assert_equals(
-			doc_entries["issue"],
-			defaults.issue,
-			"KEYBINDINGS.md issue key"
-		)
-	end
-)
-
-test(
-	"issue keybinding is lowercase <leader>gi",
-	function()
-		assert_equals(
-			doc_entries["issue"],
-			"<leader>gi",
-			"issue doc entry should be lowercase"
+			m.rhs ~= nil and m.rhs ~= "",
+			("no mapping found for %s (%s)"):format(cfg_key, resolved)
 		)
 		assert_equals(
-			defaults.issue,
-			"<leader>gi",
-			"issue config default should be lowercase"
+			m.rhs,
+			expected_plug,
+			("rhs for %s (%s)"):format(cfg_key, resolved)
 		)
 	end
-)
+end)
 
-test(
-	"PR doc entry exists",
-	function()
+-- DEFECT-002: the documented GitflowSign* highlight groups must exist after
+-- setup(), and must honor user overrides via setup({ highlights = ... }).
+test("GitflowSign* highlight groups exist after setup()", function()
+	for _, group in ipairs({
+		"GitflowSignAdded",
+		"GitflowSignModified",
+		"GitflowSignDeleted",
+		"GitflowSignConflict",
+	}) do
+		local hl = vim.api.nvim_get_hl(0, { name = group })
 		assert_true(
-			doc_entries["pr"] ~= nil,
-			"pr should be in KEYBINDINGS.md global table"
+			next(hl) ~= nil,
+			("%s should be defined after setup()"):format(group)
 		)
 	end
-)
+end)
 
-test(
-	"PR doc entry matches config default",
-	function()
-		assert_equals(
-			doc_entries["pr"],
-			defaults.pr,
-			"KEYBINDINGS.md pr key"
-		)
-	end
-)
-
-test(
-	"PR keybinding is lowercase <leader>gr",
-	function()
-		assert_equals(
-			doc_entries["pr"],
-			"<leader>gr",
-			"PR doc entry should be lowercase"
-		)
-		assert_equals(
-			defaults.pr,
-			"<leader>gr",
-			"PR config default should be lowercase"
-		)
-	end
-)
-
-test(
-	"PR and reset keybindings are distinct",
-	function()
-		assert_true(
-			defaults.pr ~= defaults.reset,
-			"pr and reset must have different keys"
-		)
-		assert_true(
-			doc_entries["pr"] ~= doc_entries["reset"],
-			"pr and reset docs must show different keys"
-		)
-	end
-)
-
-test(
-	"reset doc entry exists",
-	function()
-		assert_true(
-			doc_entries["reset"] ~= nil,
-			"reset should be in KEYBINDINGS.md"
-		)
-	end
-)
-
-test(
-	"reset doc entry matches config default",
-	function()
-		assert_equals(
-			doc_entries["reset"],
-			defaults.reset,
-			"KEYBINDINGS.md reset key"
-		)
-	end
-)
+test("GitflowSign* override via setup.highlights takes effect", function()
+	gitflow.setup({
+		highlights = {
+			GitflowSignAdded = { link = "DiffAdd" },
+		},
+	})
+	local hl = vim.api.nvim_get_hl(0, { name = "GitflowSignAdded" })
+	assert_true(next(hl) ~= nil, "GitflowSignAdded should still be defined")
+	assert_equals(hl.link, "DiffAdd", "override should set link to DiffAdd")
+	-- Reset defaults for any later scripts
+	gitflow.setup({})
+end)
 
 print(("\n%d passed, %d failed"):format(passed, failed))
 if failed > 0 then

--- a/scripts/test_stage7.lua
+++ b/scripts/test_stage7.lua
@@ -86,8 +86,8 @@ local defaults = config.defaults()
 assert_equals(defaults.sync.pull_strategy, "merge", "default pull strategy should be merge")
 assert_equals(
 	defaults.keybindings.palette,
-	"<leader>go",
-	"default palette keybinding should exist"
+	"<leader>gp",
+	"default palette keybinding should match documented default"
 )
 assert_deep_equals(
 	defaults.quick_actions.quick_commit,


### PR DESCRIPTION
## Summary

This PR fixes the three defects that a test_boyz QA sweep surfaced against the
documented keybinding and highlight contract.

The QA prober ran `require('gitflow').setup({})` under the plugin's own
`tests/minimal_init.lua`, walked every key in the documented defaults table
via `vim.fn.maparg`, and cross-checked every documented highlight group via
`nvim_get_hl`. It found a deterministic, reproducible mismatch on three
fronts; all of them live entirely in config defaults / doc tables, so the fix
is small and surgical.

## Defects addressed

### DEFECT-001 — blocking — default global keymaps diverged from docs

The README, KEYBINDINGS.md, and `doc/gitflow.txt` defaults tables all agreed
with each other (modulo DEFECT-003 below), but `lua/gitflow/config.lua`
`defaults()` was wired differently on six keys:

| Key | Docs say | Was actually |
|---|---|---|
| `gp` | push | **unmapped** |
| `gP` | pull | **unmapped** |
| `<leader>gL` | label | **unmapped** |
| `<leader>go` | open main panel | `<Plug>(GitflowPalette)` |
| `<leader>gp` | open command palette | `<Plug>(GitflowPull)` — **runs `git pull`** |
| `<leader>gr` | refresh | `<Plug>(GitflowPr)` (collision loser) |

The most dangerous cell is `<leader>gp`: documented to open the command
palette, but actually wired to `<Plug>(GitflowPull)`, which runs a
state-changing `git pull` on a user who was expecting a menu. `git pull` on
an unexpected branch or dirty worktree is a real foot-gun. Push, pull, and
label had no default keys at all.

The `<Plug>(Gitflow*)` targets themselves were all registered correctly in
`lua/gitflow/commands.lua`, and the setup loop that wires `keybindings[action]`
to its `<Plug>` target was correct. The bug lived entirely in the defaults
table literal in `lua/gitflow/config.lua` — it had been rewritten at some
point without updating the docs (or vice versa).

**Fix:** rewrite the defaults table to match the documented contract on the
20 documented keys. The 8 extra power-user actions (revert, tag, blame,
reflog, cherry_pick, rebase_interactive, actions, notifications) keep their
existing single-letter defaults so no user loses a binding they already rely
on.

### DEFECT-002 — high — `GitflowSign*` highlight override path was a no-op

`doc/gitflow.txt` L450-456 documents four sign-column highlight groups:

```
GitflowSignAdded       → GitflowAdded
GitflowSignModified    → GitflowModified
GitflowSignDeleted     → GitflowRemoved
GitflowSignConflict    → GitflowConflictLocal
```

And the general override contract in `doc/gitflow.txt` L334-344 says any
documented highlight group can be fully replaced via
`setup({ highlights = { ... } })`.

In reality those groups were never defined. `nvim_get_hl(0, { name =
"GitflowSignAdded" })` returned `{}` even after the user passed an explicit
override. The sign column still _rendered_ correctly — `sign_define` set
`texthl = "GitflowAdded"` and bypassed the documented indirection entirely —
but any user who tried to recolor signs by overriding `GitflowSignAdded`
silently got nothing.

**Fix:**
1. Add the four `GitflowSign*` groups to `build_default_groups` in
   `lua/gitflow/highlights.lua` as real `{ link = "GitflowAdded" }` etc.,
   routed through the existing override loop so user overrides land.
2. Change `SIGN_TYPES.hl` in `lua/gitflow/signs.lua` to point at the
   `GitflowSign*` groups instead of their base groups, so the documented
   indirection is actually live.

### DEFECT-003 — advisory — `<leader>gr` doc collision

All three doc files assigned `<leader>gr` to both `refresh` and `pr`. `pr`
won the collision in the running plugin, leaving `refresh` with no leader key.

**Fix:** `refresh` keeps `<leader>gr` (it is the most-used of the two).
`pr` moves to `<leader>gR` (capital R — distinct from the existing `gR`
reset chord, which has no leader). README, KEYBINDINGS.md, and
`doc/gitflow.txt` updated together so all three docs agree.

## Regression coverage

`scripts/test_keybinding_docs.lua` previously only checked `issue`, `pr`, and
`reset`, which is why DEFECT-001 snuck through — the defaults table could
drift on every other key without anything failing. This PR extends the test
to:

- Parse the Global table out of `KEYBINDINGS.md` and assert every entry
  matches `config.defaults()`.
- Parse the default keybindings table out of `doc/gitflow.txt` and assert
  every entry matches `config.defaults()`.
- Parse the Global Mappings table out of `README.md` and assert every listed
  key is actually installed by `setup()`.
- Detect key collisions in the documented defaults (locks DEFECT-003's
  resolution in).
- Walk every documented default at runtime via `vim.fn.maparg` and assert
  `.rhs` points at the expected `<Plug>(Gitflow*)` target. This is the same
  probe approach the QA prober used, so DEFECT-001-class regressions now
  fail a CI stage rather than an external audit.
- Assert `GitflowSign*` groups exist after `setup()` AND that
  `setup({ highlights = { GitflowSignAdded = { link = "DiffAdd" } } })`
  actually lands.

## Test plan

- [x] `scripts/test_keybinding_docs.lua` — 20/20 passing (was 10/10 before,
      all new checks included)
- [x] All 22 stage smoke tests (`scripts/test_*.lua` from CI's passing_stages
      list) passing
- [x] All 18 e2e specs (`tests/e2e_smoke_test.lua` + `tests/e2e/*.lua`)
      passing under `tests/minimal_init.lua`
- [x] Re-ran the exact QA probe script (`nvim_probe_keymaps.lua`): every
      documented default now resolves to the expected `<Plug>` target;
      `sign_override.has_keys = true` with `link = "DiffAdd"`, so the
      GitflowSign override path is live.

## Notes on QA reach (what this run did NOT catch)

The test_boyz QA ran Neovim **headless** with stubbed `git`/`gh`. It verified
the runtime plumbing — commands register, subcommands dispatch without
tracebacks, default keymaps match docs, highlight groups exist — but it did
not drive an interactive terminal UI. Concretely: no screenshots were
captured, no floating windows were visually rendered, no keys were pressed
in live panels, no real `git pull`/`git push` round-trips happened. So this
PR fixes the defects the QA probe could see via introspection, and the new
regression test uses the same introspection approach. Things the QA sweep
could not observe (live TUI rendering, colors, panel layout under odd
terminal sizes, multi-keystroke panel flows) remain out of scope; they
belong to a follow-up PR that wires a real TUI harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)