### PR TITLE
feat(ui): add shared state-feedback and in-context hints across panels

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,6 +69,7 @@ jobs:
             scripts/test_palette_accent_parity.lua
             scripts/test_reset.lua
             scripts/test_review_loop.lua
+            scripts/test_state_components.lua
             scripts/test_unified_theme.lua
           )
           exit_code=0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## UI rendering conventions
+
+- Panels render via the `ui_render.builder()` chunk builder plus the shared
+  helpers in `lua/gitflow/ui/components.lua`. Prefer these over ad-hoc line
+  arrays so every surface shares one visual language.
+- Shared state feedback lives in `components`: `loading()`/`loading_lines()`,
+  `error_state()`, the enriched `empty(B, text, { icon, hint })`, and
+  `hint_group()`. New highlight groups for these are in `highlights.lua`
+  (`GitflowLoading*`, `GitflowState*`, `GitflowEmpty*`, `GitflowHintGroupLabel`)
+  and link to standard semantic groups so they follow the user's colorscheme.
+- Key hints: floats advertise keys in the window footer; splits get an in-buffer
+  bar via `components.split_hint_bar(B, render_opts, pairs)`, which renders
+  nothing when `ui_render.is_floating(render_opts)` is true. Keep the panel's
+  required last line (e.g. status' `Current branch: <branch>`) after it.
+
+## Testing
+
+- Gates are the lists in `.github/workflows/e2e.yml`: every `tests/e2e/*.lua`
+  spec (run with `-u tests/minimal_init.lua`) plus the enumerated
+  `scripts/test_*.lua` stage tests (run with `-u NONE`). A new `scripts/`
+  test only runs in CI if it is added to that `passing_stages` array.
+- `scripts/test_stage3.lua` has a pre-existing failure in its branch-rename
+  section and is intentionally NOT in the CI gate list — do not treat it as a
+  regression signal.
+- There is no `stylua.toml`; the repo hand-formats (tabs, manual line wraps) and
+  is not stylua-default-clean, so match surrounding style rather than running
+  `stylua --write` across files.
+- Some specs assert panel text substrings (e.g. `gear_system_spec`,
+  `test_stage6` check the conflict summary). When changing presentation copy,
+  update those assertions to the new wording.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/doc/gitflow.txt
+++ b/doc/gitflow.txt
@@ -480,6 +480,17 @@ Link-based groups (track your colorscheme automatically):
     GitflowPaletteNormal            NormalFloat
     GitflowResetMergeBase           WarningMsg
     GitflowFormActiveField          CursorLine
+    GitflowLoadingText              Comment
+    GitflowStateError               DiagnosticError
+    GitflowStateErrorIcon           DiagnosticError
+    GitflowStateErrorDetail         Comment
+    GitflowEmptyText                Comment
+    GitflowEmptyHint                Comment
+
+These shared state groups give every panel a cohesive loading / error / empty
+affordance: `GitflowLoadingText` styles in-progress labels, the
+`GitflowStateError*` family styles in-buffer error blocks, and the
+`GitflowEmpty*` family styles empty-state placeholders and their action hints.
 
 Accent-colored groups (dark-background defaults shown below; light mode uses
 `PALETTE_LIGHT` values from the table above):
@@ -500,6 +511,9 @@ Accent-colored groups (dark-background defaults shown below; light mode uses
     GitflowPaletteHeaderIcon    fg=#56B6C2, bg=#DCA561, bold
     GitflowPaletteEntryIcon     fg=#56B6C2
     GitflowPaletteBackdrop      bg=#000000
+    GitflowLoadingIcon          fg=#56B6C2, bold
+    GitflowEmptyIcon            fg=#3E4452
+    GitflowHintGroupLabel       fg=#DCA561, bold
 
 To make these groups track your colorscheme instead of using hardcoded
 colors, override them with link-based definitions: >lua

--- a/lua/gitflow/git/rebase.lua
+++ b/lua/gitflow/git/rebase.lua
@@ -5,6 +5,8 @@ local git = require("gitflow.git")
 ---@field sha string
 ---@field short_sha string
 ---@field subject string
+---@field author string
+---@field relative_time string
 
 local M = {}
 
@@ -26,13 +28,16 @@ end
 function M.parse_commits(output)
 	local entries = {}
 	for _, line in ipairs(vim.split(output, "\n", { trimempty = true })) do
-		local sha, subject = line:match("^([0-9a-fA-F]+)\t(.*)$")
+		local sha, author, rel_time, subject =
+			line:match("^([0-9a-fA-F]+)\t([^\t]*)\t([^\t]*)\t(.*)$")
 		if sha then
 			entries[#entries + 1] = {
 				action = "pick",
 				sha = sha,
 				short_sha = sha:sub(1, 7),
 				subject = subject,
+				author = author,
+				relative_time = rel_time,
 			}
 		end
 	end
@@ -49,7 +54,7 @@ function M.list_commits(base_ref, opts, cb)
 	local count = tonumber(options.count) or 50
 	local args = {
 		"log",
-		"--pretty=format:%H\t%s",
+		"--pretty=format:%H\t%an\t%ar\t%s",
 		"--reverse",
 	}
 	if count > 0 then

--- a/lua/gitflow/highlights.lua
+++ b/lua/gitflow/highlights.lua
@@ -77,6 +77,7 @@ local function build_default_groups(palette)
 		GitflowWorktreeCurrent = { link = "GitflowBranchCurrent" },
 		GitflowWorktreeLocked = { link = "WarningMsg" },
 		GitflowWorktreePrunable = { link = "Comment" },
+		GitflowWorktreeDirty = { link = "DiagnosticWarn" },
 		-- PR state
 		GitflowPROpen = { link = "DiagnosticOk" },
 		GitflowPRMerged = { link = "Special" },

--- a/lua/gitflow/highlights.lua
+++ b/lua/gitflow/highlights.lua
@@ -206,6 +206,21 @@ local function build_default_groups(palette)
 		GitflowFormPlaceholder = { fg = palette.separator_fg, italic = true },
 		GitflowFormSection = { fg = palette.accent_secondary, bold = true },
 		GitflowFormHint = { link = "Comment" },
+		-- Shared state feedback — loading / error / empty placeholders so every
+		-- surface shows the same cohesive language instead of plain text. The
+		-- error/spinner accents link to standard semantic groups so they follow
+		-- the user's colorscheme.
+		GitflowLoadingIcon = { fg = palette.accent_primary, bold = true },
+		GitflowLoadingText = { link = "Comment" },
+		GitflowStateError = { link = "DiagnosticError" },
+		GitflowStateErrorIcon = { link = "DiagnosticError" },
+		GitflowStateErrorDetail = { link = "Comment" },
+		GitflowEmptyIcon = { fg = palette.separator_fg },
+		GitflowEmptyText = { link = "Comment" },
+		GitflowEmptyHint = { link = "Comment" },
+		-- Grouped key-hint blocks (review panel and other dense surfaces): a dim
+		-- group label sits above its hints, matching the form-section accent.
+		GitflowHintGroupLabel = { fg = palette.accent_secondary, bold = true },
 	}
 end
 

--- a/lua/gitflow/icons.lua
+++ b/lua/gitflow/icons.lua
@@ -50,6 +50,12 @@ local NF = {
 	merge = "\u{f43f}",            -- nf-oct-git_merge
 	dot = "\u{f444}",              -- nf-oct-dot_fill
 	chevron = "\u{f432}",          -- nf-oct-chevron_right
+	-- state feedback (loading / error / empty)
+	loading = "\u{f43a}",          -- nf-oct-clock (static "in progress" glyph)
+	error = "\u{f421}",            -- nf-oct-x_circle_fill
+	info = "\u{f449}",             -- nf-oct-info
+	empty = "\u{f487}",            -- nf-oct-inbox
+	keyboard = "\u{f40b}",         -- nf-oct-keyboard (hint blocks)
 }
 
 ---@type table<string, table<string, {nerd: string, ascii: string}>>
@@ -134,6 +140,11 @@ local registry = {
 		merge = { nerd = NF.merge, ascii = "" },
 		dot = { nerd = NF.dot, ascii = "\u{b7}" },
 		chevron = { nerd = NF.chevron, ascii = ">" },
+		loading = { nerd = NF.loading, ascii = "\u{2026}" },
+		error = { nerd = NF.error, ascii = "!" },
+		info = { nerd = NF.info, ascii = "i" },
+		empty = { nerd = NF.empty, ascii = "\u{2014}" },
+		keyboard = { nerd = NF.keyboard, ascii = "::" },
 	},
 }
 

--- a/lua/gitflow/inline_blame.lua
+++ b/lua/gitflow/inline_blame.lua
@@ -111,6 +111,10 @@ local function parse_porcelain(output)
 	}
 end
 
+-- Keep the inline annotation from running off the screen on long commit
+-- subjects; the full message is still available in the blame panel.
+local INLINE_SUMMARY_MAX = 72
+
 ---@param info { author: string, date: string, summary: string, committed: boolean }
 ---@return string
 local function format_blame(info)
@@ -119,7 +123,11 @@ local function format_blame(info)
 	end
 	local parts = ("%s, %s"):format(info.author, info.date)
 	if info.summary ~= "" then
-		parts = parts .. " • " .. info.summary
+		local summary = info.summary
+		if vim.fn.strdisplaywidth(summary) > INLINE_SUMMARY_MAX then
+			summary = vim.fn.strcharpart(summary, 0, INLINE_SUMMARY_MAX - 1) .. "\u{2026}"
+		end
+		parts = parts .. " • " .. summary
 	end
 	return parts
 end

--- a/lua/gitflow/panels/blame.lua
+++ b/lua/gitflow/panels/blame.lua
@@ -17,6 +17,11 @@ local components = require("gitflow.ui.components")
 local M = {}
 local BLAME_FLOAT_TITLE = "  Gitflow Blame  "
 local BLAME_FLOAT_FOOTER = " <CR> open commit · r refresh · q close "
+local BLAME_HINTS = {
+	{ "<CR>", "open commit" },
+	{ "r", "refresh" },
+	{ "q", "close" },
+}
 local BLAME_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_blame_hl")
 
 ---@type GitflowBlamePanelState
@@ -37,7 +42,7 @@ local function ensure_window(cfg)
 	if not bufnr then
 		bufnr = ui.buffer.create("blame", {
 			filetype = "gitflowblame",
-			lines = { "Loading blame..." },
+			lines = components.loading_lines("Loading blame…"),
 		})
 		M.state.bufnr = bufnr
 	end
@@ -89,6 +94,43 @@ local function ensure_window(cfg)
 	end, { buffer = bufnr, silent = true, nowait = true })
 end
 
+---Paint the buffer with a single styled state block (loading / error) sharing
+---the same header chrome as the rendered blame so transitions don't flicker.
+---@param paint fun(B: GitflowRenderBuilder)
+local function render_state(paint)
+	local render_opts = { bufnr = M.state.bufnr, winid = M.state.winid }
+	local B = ui_render.builder()
+	components.header(B, "Gitflow Blame", render_opts)
+	B:blank()
+	paint(B)
+	ui.buffer.update("blame", B.lines)
+	M.state.line_entries = {}
+	local bufnr = M.state.bufnr
+	if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+		return
+	end
+	B:apply(bufnr, BLAME_HIGHLIGHT_NS)
+end
+
+local function render_loading()
+	render_state(function(B)
+		local short_path = vim.fn.fnamemodify(M.state.filepath or "", ":~:.")
+		components.loading(B, "Computing blame…", {
+			detail = short_path ~= "" and short_path or nil,
+		})
+	end)
+end
+
+---@param message string
+local function render_error(message)
+	render_state(function(B)
+		components.error_state(B, "Could not compute blame", {
+			detail = message,
+			hint = "Press r to retry · q to close",
+		})
+	end)
+end
+
 ---@param str string|nil
 ---@param width integer
 ---@return string  padding spaces to reach the given display width
@@ -135,7 +177,9 @@ local function render(entries, current_branch)
 	)
 
 	if #entries == 0 then
-		components.empty(B, "no blame data")
+		components.empty(B, "No blame data for this file", {
+			hint = "The file may be untracked or have no committed history.",
+		})
 	else
 		-- Compute max widths for aligned columns.
 		local max_sha, max_author, max_date = 0, 0, 0
@@ -168,6 +212,8 @@ local function render(entries, current_branch)
 			line_entries[line_no] = entry
 		end
 	end
+
+	components.split_hint_bar(B, render_opts, BLAME_HINTS)
 
 	ui.buffer.update("blame", B.lines)
 	M.state.line_entries = line_entries
@@ -215,6 +261,7 @@ function M.open(cfg, opts)
 	end
 
 	ensure_window(cfg)
+	render_loading()
 	M.refresh()
 end
 
@@ -230,6 +277,7 @@ function M.refresh()
 			"No file to blame (open a file first)",
 			vim.log.levels.WARN
 		)
+		render_error("No file to blame — open a file first.")
 		return
 	end
 
@@ -237,6 +285,7 @@ function M.refresh()
 		git_blame.run({ filepath = filepath }, function(err, entries)
 			if err then
 				utils.notify(err, vim.log.levels.ERROR)
+				render_error(err)
 				return
 			end
 			render(entries or {}, branch or "(unknown)")

--- a/lua/gitflow/panels/conflict.lua
+++ b/lua/gitflow/panels/conflict.lua
@@ -4,6 +4,8 @@ local git = require("gitflow.git")
 local git_conflict = require("gitflow.git.conflict")
 local conflict_view = require("gitflow.ui.conflict")
 local ui_render = require("gitflow.ui.render")
+local components = require("gitflow.ui.components")
+local icons = require("gitflow.icons")
 
 ---@class GitflowConflictFileEntry
 ---@field path string
@@ -27,6 +29,13 @@ local CONFLICT_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_conflict_hl
 local CONFLICT_FLOAT_TITLE = "Gitflow Conflicts"
 local CONFLICT_FLOAT_FOOTER =
 	"<CR> open 3-way  r refresh  C continue  A abort  q close"
+local CONFLICT_HINTS = {
+	{ "<CR>", "open 3-way" },
+	{ "C", "continue" },
+	{ "A", "abort" },
+	{ "r", "refresh" },
+	{ "q", "close" },
+}
 
 ---@type GitflowConflictPanelState
 M.state = {
@@ -88,7 +97,7 @@ local function ensure_window(cfg)
 	if not bufnr then
 		bufnr = ui.buffer.create("conflict", {
 			filetype = "gitflowconflict",
-			lines = { "Loading conflicts..." },
+			lines = components.loading_lines("Loading conflicts…"),
 		})
 		M.state.bufnr = bufnr
 	end
@@ -152,6 +161,39 @@ local function ensure_window(cfg)
 	end, { buffer = bufnr, silent = true, nowait = true })
 end
 
+---Paint a single styled state block (loading / error) with shared chrome.
+---@param paint fun(B: GitflowRenderBuilder)
+local function render_state(paint)
+	local render_opts = { bufnr = M.state.bufnr, winid = M.state.winid }
+	local B = ui_render.builder()
+	components.header(B, "Gitflow Conflicts", render_opts)
+	B:blank()
+	paint(B)
+	ui.buffer.update("conflict", B.lines)
+	M.state.line_entries = {}
+	local bufnr = M.state.bufnr
+	if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+		return
+	end
+	B:apply(bufnr, CONFLICT_HIGHLIGHT_NS)
+end
+
+local function render_loading()
+	render_state(function(B)
+		components.loading(B, "Scanning for conflicts…")
+	end)
+end
+
+---@param message string
+local function render_error(message)
+	render_state(function(B)
+		components.error_state(B, "Could not list conflicts", {
+			detail = message,
+			hint = "Press r to retry · q to close",
+		})
+	end)
+end
+
 ---@param files GitflowConflictFileEntry[]
 ---@param operation GitflowConflictOperation|nil
 local function render(files, operation)
@@ -159,28 +201,73 @@ local function render(files, operation)
 		bufnr = M.state.bufnr,
 		winid = M.state.winid,
 	}
-	local lines = ui_render.panel_header("Gitflow Conflicts", render_opts)
-	local header_line_count = #lines
-	lines[#lines + 1] = ("Active operation: %s"):format(operation_label(operation))
-	lines[#lines + 1] = ("Unresolved files: %d"):format(#files)
-	lines[#lines + 1] = ""
-	local line_entries = {}
+	local B = ui_render.builder()
+	components.header(B, "Gitflow Conflicts", render_opts)
 
+	-- Summary bar: active operation + unresolved count. When everything is
+	-- resolved the count flips to an "all resolved" affordance in the ok accent.
+	local op = operation_label(operation)
+	local resolved = #files == 0
+	B:push({
+		{ "  ", nil },
+		{ icons.get("ui", "merge") .. "  ", "GitflowSectionIcon" },
+		{ op ~= "none" and (op .. " in progress") or "No active operation",
+			"GitflowSectionTitle" },
+		{ "     ", nil },
+		{
+			resolved and (icons.get("git_state", "staged") .. " all resolved")
+				or ("%s %d unresolved"):format(
+					icons.get("git_state", "conflict"), #files
+				),
+			resolved and "GitflowReviewApproved" or "GitflowConflictRemote",
+		},
+	})
+	B:blank()
+
+	components.section(
+		B,
+		icons.get("git_state", "conflict"),
+		("Conflicted files (%d)"):format(#files)
+	)
+
+	local line_entries = {}
 	if #files == 0 then
-		lines[#lines + 1] = ui_render.empty()
+		if op ~= "none" then
+			components.empty(B, "All conflicts resolved", {
+				icon = icons.get("git_state", "staged"),
+				hint = ("Press C to continue the %s, or A to abort."):format(op),
+			})
+		else
+			components.empty(B, "No conflicts", {
+				icon = icons.get("git_state", "staged"),
+				hint = "Your working tree has no unmerged paths.",
+			})
+		end
 	else
 		for _, item in ipairs(files) do
-			local suffix = (" (%d hunks)"):format(item.hunk_count)
-			lines[#lines + 1] = ui_render.entry(("%s%s"):format(item.path, suffix))
-			line_entries[#lines] = item
+			local line_no = B:push({
+				{ " ", nil },
+				{ icons.get("git_state", "conflict") .. "  ", "GitflowConflictRemote" },
+				{ item.path, "GitflowCardTitle" },
+				{ ("   (%d hunk%s)"):format(
+					item.hunk_count, item.hunk_count == 1 and "" or "s"
+				), "GitflowMeta" },
+			})
+			line_entries[line_no] = item
 
 			if item.marker_error then
-				lines[#lines + 1] = ("    ! %s"):format(item.marker_error)
+				B:push({
+					{ "     ", nil },
+					{ icons.get("ui", "error") .. " ", "GitflowStateErrorIcon" },
+					{ item.marker_error, "GitflowStateError" },
+				})
 			end
 		end
 	end
 
-	ui.buffer.update("conflict", lines)
+	components.split_hint_bar(B, render_opts, CONFLICT_HINTS)
+
+	ui.buffer.update("conflict", B.lines)
 	M.state.files = files
 	M.state.line_entries = line_entries
 	M.state.active_operation = operation
@@ -189,26 +276,8 @@ local function render(files, operation)
 	if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
 		return
 	end
-
-	local entry_highlights = {}
-	entry_highlights[header_line_count + 1] = "GitflowHeader"
-	entry_highlights[header_line_count + 2] = "GitflowHeader"
-
-	-- File entry lines
-	for line_no, _ in pairs(line_entries) do
-		entry_highlights[line_no] = "GitflowConflictBase"
-	end
-
-	-- Error marker lines
-	for line_no, line in ipairs(lines) do
-		if vim.startswith(line, "    ! ") then
-			entry_highlights[line_no] = "GitflowConflictRemote"
-		end
-	end
-
-	ui_render.apply_panel_highlights(bufnr, CONFLICT_HIGHLIGHT_NS, lines, {
-		entry_highlights = entry_highlights,
-	})
+	B:apply(bufnr, CONFLICT_HIGHLIGHT_NS)
+	components.cursorline(M.state.winid, true)
 end
 
 ---@return GitflowConflictFileEntry|nil
@@ -306,6 +375,7 @@ function M.open(cfg, opts)
 	M.state.cfg = cfg
 	M.state.pending_open_path = opts and opts.path or nil
 	ensure_window(cfg)
+	render_loading()
 	M.refresh()
 end
 
@@ -318,6 +388,7 @@ function M.refresh()
 		git_conflict.list({}, function(err, paths)
 			if err then
 				utils.notify(err, vim.log.levels.ERROR)
+				render_error(err)
 				return
 			end
 

--- a/lua/gitflow/panels/rebase.lua
+++ b/lua/gitflow/panels/rebase.lua
@@ -7,7 +7,6 @@ local git_conflict = require("gitflow.git.conflict")
 local icons = require("gitflow.icons")
 local ui_render = require("gitflow.ui.render")
 local components = require("gitflow.ui.components")
-local list_picker = require("gitflow.ui.list_picker")
 local status_panel = require("gitflow.panels.status")
 
 ---@class GitflowRebasePanelState
@@ -21,18 +20,30 @@ local status_panel = require("gitflow.panels.status")
 ---@field cfg GitflowConfig|nil
 ---@field picker_request_id integer
 ---@field refresh_request_id integer
+---@field focused_line integer|nil
+---@field preview_winid integer|nil
+---@field preview_bufnr integer|nil
+---@field base_line_branches table<integer, GitflowBranchEntry>
 
 local M = {}
 local REBASE_FLOAT_TITLE = "Gitflow Interactive Rebase"
 local REBASE_FLOAT_FOOTER =
-	" <CR> cycle · p/r/e/s/f/d actions · J/K move · X execute"
-		.. " · b base · q close "
+	" <CR> cycle · p/r/e/s/f/d action · J/K move · X execute"
+		.. " · P preview · b base · q close "
 -- Compact in-buffer hints for split layout (floats use the footer above).
 local REBASE_HINTS = {
-	{ "<CR>", "cycle action" },
+	{ "<CR>", "cycle" },
+	{ "p/r/e/s/f/d", "action" },
 	{ "J/K", "move" },
 	{ "X", "execute" },
+	{ "P", "preview" },
 	{ "b", "base" },
+	{ "q", "close" },
+}
+-- Hints for the base-branch picker stage.
+local BASE_FLOAT_FOOTER = " <CR> select · q close "
+local BASE_HINTS = {
+	{ "<CR>", "select" },
 	{ "q", "close" },
 }
 local REBASE_HIGHLIGHT_NS =
@@ -41,12 +52,21 @@ local REBASE_HIGHLIGHT_NS =
 local ACTIONS = { "pick", "reword", "edit", "squash", "fixup", "drop" }
 
 local ACTION_HIGHLIGHTS = {
-	pick = "GitflowRebasePick",
+	pick   = "GitflowRebasePick",
 	reword = "GitflowRebaseReword",
-	edit = "GitflowRebaseEdit",
+	edit   = "GitflowRebaseEdit",
 	squash = "GitflowRebaseSquash",
-	fixup = "GitflowRebaseFixup",
-	drop = "GitflowRebaseDrop",
+	fixup  = "GitflowRebaseFixup",
+	drop   = "GitflowRebaseDrop",
+}
+
+local ACTION_GLYPHS = {
+	pick   = "●",
+	reword = "~",
+	edit   = "≡",
+	squash = "⊕",
+	fixup  = "⊙",
+	drop   = "✗",
 }
 
 ---@type GitflowRebasePanelState
@@ -61,6 +81,10 @@ M.state = {
 	cfg = nil,
 	picker_request_id = 0,
 	refresh_request_id = 0,
+	focused_line = nil,
+	preview_winid = nil,
+	preview_bufnr = nil,
+	base_line_branches = {},
 }
 
 local function next_picker_request_id()
@@ -114,6 +138,9 @@ local function next_action(current)
 	return "pick"
 end
 
+local render_todo           -- forward declaration; defined after ensure_window
+local refresh_float_footer  -- forward declaration; defined before render_base_picker
+
 ---@param cfg GitflowConfig
 local function ensure_window(cfg)
 	local bufnr = M.state.bufnr
@@ -125,6 +152,29 @@ local function ensure_window(cfg)
 			lines = { "Loading branches..." },
 		})
 		M.state.bufnr = bufnr
+
+		vim.api.nvim_create_autocmd("CursorMoved", {
+			buffer = bufnr,
+			callback = function()
+				if vim.api.nvim_get_current_buf() ~= bufnr then
+					return
+				end
+				local line = vim.api.nvim_win_get_cursor(0)[1]
+				if line == M.state.focused_line then
+					return
+				end
+				M.state.focused_line = line
+				if M.state.stage ~= "todo" then
+					return
+				end
+				render_todo()
+				if M.state.preview_winid
+					and vim.api.nvim_win_is_valid(M.state.preview_winid)
+				then
+					M.refresh_preview()
+				end
+			end,
+		})
 	end
 
 	vim.api.nvim_set_option_value(
@@ -148,7 +198,7 @@ local function ensure_window(cfg)
 			title = REBASE_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
 			footer = cfg.ui.float.footer
-				and REBASE_FLOAT_FOOTER or nil,
+				and BASE_FLOAT_FOOTER or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil
@@ -166,9 +216,13 @@ local function ensure_window(cfg)
 		})
 	end
 
-	-- Action cycling
+	-- CR routes to branch selection in "base" stage, action cycling in "todo".
 	vim.keymap.set("n", "<CR>", function()
-		M.cycle_action()
+		if M.state.stage == "base" then
+			M.select_base_branch()
+		else
+			M.cycle_action()
+		end
 	end, { buffer = bufnr, silent = true })
 
 	-- Direct action keys
@@ -215,6 +269,11 @@ local function ensure_window(cfg)
 		M.show_base_picker()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
+	-- Toggle diff preview for focused commit
+	vim.keymap.set("n", "P", function()
+		M.toggle_preview()
+	end, { buffer = bufnr, silent = true, nowait = true })
+
 	-- Close
 	vim.keymap.set("n", "q", function()
 		M.close()
@@ -222,7 +281,7 @@ local function ensure_window(cfg)
 end
 
 ---Render the interactive rebase todo list.
-local function render_todo()
+render_todo = function()
 	local render_opts = {
 		bufnr = M.state.bufnr,
 		winid = M.state.winid,
@@ -250,16 +309,16 @@ local function render_todo()
 		{ current_branch, "GitflowBranchCurrent" },
 	})
 
-	-- Base ref header. The literal "Base: <ref>" text is load-bearing
-	-- (asserted by tests), so keep the key and value adjacent.
-	B:push({
-		{ "  ", nil },
-		{ base_icon .. "  ", "GitflowSectionIcon" },
-		{ "Base: ", "GitflowMetaKey" },
+	-- Base ref as a meta_row (item 4).
+	components.meta_row(B, "Base:", {
+		{ base_icon .. " ", "GitflowSectionIcon" },
 		{ M.state.base_ref or "(none)", "GitflowBranchCurrent" },
-	})
+	}, { width = 7 })
 	B:blank()
 
+	-- Snapshot the previous line_entries for the detail bar lookup below
+	-- (we update M.state.line_entries at the end of this function).
+	local prev_line_entries = M.state.line_entries
 	local line_entries = {}
 
 	components.section(B, commit_icon, ("Commits (%d)"):format(count))
@@ -269,20 +328,55 @@ local function render_todo()
 		for _, entry in ipairs(M.state.entries) do
 			local action_group = ACTION_HIGHLIGHTS[entry.action]
 				or "GitflowRebasePick"
-			-- Action left-padded to 6 cols ("pick  ") + a separator
-			-- space, keeping the "pick" + subject pairing tests rely on.
-			local action_label = ("%-6s"):format(entry.action)
-			local subject = entry.subject ~= ""
-				and ("  " .. entry.subject) or ""
-			local line_no = B:push({
-				{ " ", nil },
-				{ action_label .. " ", action_group },
+			local glyph = ACTION_GLYPHS[entry.action] or "●"
+			-- squash/fixup items are indented under their pick target
+			-- (item 6: squash/fixup chain indentation).
+			local is_chain = entry.action == "squash"
+				or entry.action == "fixup"
+			local lead = is_chain and "   " or " "
+			local lead2 = is_chain and "       " or "     "
+
+			-- Line 1: glyph badge + sha + subject (items 1 & 2).
+			local line1 = B:push({
+				{ lead, nil },
+				{ glyph .. " ", action_group },
+				{ ("%-6s"):format(entry.action) .. "  ", action_group },
 				{ commit_icon .. " ", "GitflowRebaseHash" },
 				{ entry.short_sha, "GitflowRebaseHash" },
-				{ subject, "GitflowCardTitle" },
+				{ "  " .. (entry.subject or ""), "GitflowCardTitle" },
 			})
-			line_entries[line_no] = entry
+			line_entries[line1] = entry
+
+			-- Line 2: author + relative time, dimmed (item 1).
+			local line2 = B:push({
+				{ lead2, nil },
+				{ entry.author or "", "GitflowMeta" },
+				{ " · ", "GitflowMetaKey" },
+				{ entry.relative_time or "", "GitflowMeta" },
+			})
+			line_entries[line2] = entry
 		end
+	end
+
+	-- Detail bar: shows author/time/subject for the focused commit (item 8).
+	B:blank()
+	local focused_entry = prev_line_entries
+		and prev_line_entries[M.state.focused_line]
+	if focused_entry then
+		B:push({
+			{ "  ", nil },
+			{ commit_icon .. " ", "GitflowSectionIcon" },
+			{ focused_entry.author or "", "GitflowMeta" },
+			{ " · ", "GitflowMetaKey" },
+			{ focused_entry.relative_time or "", "GitflowMeta" },
+			{ "   ", nil },
+			{ focused_entry.subject or "", "GitflowCardTitle" },
+		})
+	else
+		B:push({
+			{ "   ", nil },
+			{ "move cursor to a commit to inspect", "GitflowMeta" },
+		})
 	end
 
 	components.split_hint_bar(B, render_opts, REBASE_HINTS)
@@ -296,6 +390,7 @@ local function render_todo()
 	end
 	B:apply(bufnr, REBASE_HIGHLIGHT_NS)
 	components.cursorline(M.state.winid, true)
+	refresh_float_footer()
 end
 
 ---Find the index in M.state.entries for the entry under the cursor.
@@ -319,6 +414,241 @@ local function entry_index_under_cursor()
 	return nil
 end
 
+---@return integer|nil
+local function ensure_preview_buffer()
+	if M.state.preview_bufnr
+		and vim.api.nvim_buf_is_valid(M.state.preview_bufnr)
+	then
+		return M.state.preview_bufnr
+	end
+	local bufnr = vim.api.nvim_create_buf(false, true)
+	vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = bufnr })
+	vim.api.nvim_set_option_value("buftype", "nofile", { buf = bufnr })
+	vim.api.nvim_set_option_value("filetype", "diff", { buf = bufnr })
+	vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+	M.state.preview_bufnr = bufnr
+	return bufnr
+end
+
+---Fetch and display `git show` for the currently focused commit in the preview
+---window. No-ops when the preview buffer or focused entry is absent.
+function M.refresh_preview()
+	local entry = M.state.line_entries
+		and M.state.line_entries[M.state.focused_line]
+	local preview_bufnr = M.state.preview_bufnr
+	if not entry
+		or not preview_bufnr
+		or not vim.api.nvim_buf_is_valid(preview_bufnr)
+	then
+		return
+	end
+	git.git(
+		{ "show", "--stat", "--patch", entry.sha },
+		{},
+		function(result)
+			if not vim.api.nvim_buf_is_valid(preview_bufnr) then
+				return
+			end
+			local lines = vim.split(result.stdout or "", "\n")
+			vim.schedule(function()
+				if not vim.api.nvim_buf_is_valid(preview_bufnr) then
+					return
+				end
+				vim.api.nvim_set_option_value(
+					"modifiable", true, { buf = preview_bufnr }
+				)
+				vim.api.nvim_buf_set_lines(
+					preview_bufnr, 0, -1, false, lines
+				)
+				vim.api.nvim_set_option_value(
+					"modifiable", false, { buf = preview_bufnr }
+				)
+			end)
+		end
+	)
+end
+
+---Toggle the diff-preview float for the focused commit (item 9).
+---Opens a side float showing `git show <sha>`; pressing P again closes it.
+function M.toggle_preview()
+	if M.state.stage ~= "todo" then
+		return
+	end
+	if M.state.preview_winid
+		and vim.api.nvim_win_is_valid(M.state.preview_winid)
+	then
+		vim.api.nvim_win_close(M.state.preview_winid, true)
+		M.state.preview_winid = nil
+		return
+	end
+
+	local entry = M.state.line_entries
+		and M.state.line_entries[M.state.focused_line]
+	if not entry then
+		utils.notify("Move cursor to a commit first", vim.log.levels.WARN)
+		return
+	end
+
+	local preview_bufnr = ensure_preview_buffer()
+	local columns = vim.o.columns
+	local lines_h = vim.o.lines - vim.o.cmdheight
+	local width = math.floor(columns * 0.48)
+	local height = math.floor(lines_h * 0.72)
+	local col = math.floor(columns * 0.51)
+	local row = math.floor((lines_h - height) / 2)
+
+	local preview_winid = vim.api.nvim_open_win(preview_bufnr, false, {
+		relative = "editor",
+		style = "minimal",
+		width = width,
+		height = height,
+		row = row,
+		col = col,
+		border = "rounded",
+		title = " git show ",
+		title_pos = "center",
+		zindex = 200,
+	})
+	vim.api.nvim_set_option_value(
+		"winhighlight",
+		"NormalFloat:GitflowNormal,FloatBorder:GitflowBorder"
+			.. ",FloatTitle:GitflowTitle",
+		{ win = preview_winid }
+	)
+	M.state.preview_winid = preview_winid
+
+	vim.api.nvim_create_autocmd("WinClosed", {
+		pattern = tostring(preview_winid),
+		once = true,
+		callback = function()
+			if M.state.preview_winid == preview_winid then
+				M.state.preview_winid = nil
+			end
+			if M.state.preview_bufnr
+				and vim.api.nvim_buf_is_valid(M.state.preview_bufnr)
+			then
+				pcall(
+					vim.api.nvim_buf_delete,
+					M.state.preview_bufnr,
+					{ force = true }
+				)
+			end
+			M.state.preview_bufnr = nil
+		end,
+	})
+
+	M.refresh_preview()
+end
+
+---Update the float window footer to match the current stage (best-effort).
+refresh_float_footer = function()
+	local winid = M.state.winid
+	if not winid or not vim.api.nvim_win_is_valid(winid) then
+		return
+	end
+	if vim.fn.has("nvim-0.10") ~= 1 then
+		return
+	end
+	local win_cfg = vim.api.nvim_win_get_config(winid)
+	if not win_cfg.relative or win_cfg.relative == "" then
+		return
+	end
+	local footer = M.state.stage == "base"
+		and BASE_FLOAT_FOOTER or REBASE_FLOAT_FOOTER
+	pcall(vim.api.nvim_win_set_config, winid, {
+		footer = footer,
+		footer_pos = win_cfg.footer_pos or "center",
+	})
+end
+
+---Render the branch list into the rebase panel for the "base" picker stage.
+---@param branches GitflowBranchEntry[]
+local function render_base_picker(branches)
+	local render_opts = {
+		bufnr = M.state.bufnr,
+		winid = M.state.winid,
+	}
+	local B = ui_render.builder()
+	components.header(B, "Gitflow Interactive Rebase", render_opts)
+
+	local branch_icon = icons.get("branch", "current")
+	components.section(B, branch_icon, "Select Base Branch")
+
+	local local_entries, remote_entries = git_branch.partition(branches)
+	local base_line_branches = {}
+
+	local function append_branch_section(title, entries)
+		if #entries == 0 then
+			return
+		end
+		B:push({
+			{ "  " .. title, "GitflowSectionTitle" },
+		})
+		B:raw(
+			"  " .. string.rep("-", math.max(8, #title + 2)),
+			"GitflowSeparator"
+		)
+		for _, entry in ipairs(entries) do
+			local icon, group
+			if entry.is_current then
+				icon = icons.get("branch", "current")
+				group = "GitflowBranchCurrent"
+			elseif entry.is_remote then
+				icon = icons.get("branch", "remote")
+				group = "GitflowBranchRemote"
+			else
+				icon = icons.get("branch", "local_branch")
+				group = "GitflowCardTitle"
+			end
+			local chunks = {
+				{ "    ", nil },
+				{ (icon ~= "" and icon .. "  " or ""), group },
+				{ entry.name, group },
+			}
+			if entry.is_current then
+				chunks[#chunks + 1] = {
+					"  (current)", "GitflowMeta",
+				}
+			end
+			local line_no = B:push(chunks)
+			base_line_branches[line_no] = entry
+		end
+		B:blank()
+	end
+
+	append_branch_section("Local", local_entries)
+	append_branch_section("Remote", remote_entries)
+
+	components.split_hint_bar(B, render_opts, BASE_HINTS)
+
+	ui.buffer.update("rebase", B.lines)
+	M.state.base_line_branches = base_line_branches
+
+	local bufnr = M.state.bufnr
+	if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+		return
+	end
+	B:apply(bufnr, REBASE_HIGHLIGHT_NS)
+	components.cursorline(M.state.winid, true)
+	refresh_float_footer()
+end
+
+---Confirm the branch under the cursor as the rebase base and switch to the
+---todo view.
+function M.select_base_branch()
+	local line = vim.api.nvim_win_get_cursor(0)[1]
+	local branch = M.state.base_line_branches
+		and M.state.base_line_branches[line]
+	if not branch then
+		utils.notify("Move cursor to a branch first", vim.log.levels.WARN)
+		return
+	end
+	next_picker_request_id()
+	M.state.base_ref = branch.name
+	M.state.stage = "todo"
+	M.refresh()
+end
+
 ---@param cfg GitflowConfig
 function M.open(cfg)
 	M.state.cfg = cfg
@@ -328,12 +658,13 @@ function M.open(cfg)
 end
 
 function M.show_base_picker()
-	local cfg = M.state.cfg
-	if not cfg then
+	if not M.state.cfg then
 		return
 	end
 
+	M.state.stage = "base"
 	local request_id = next_picker_request_id()
+
 	git_branch.list({}, function(err, branches)
 		if not is_active_picker_request(request_id) then
 			return
@@ -345,17 +676,14 @@ function M.show_base_picker()
 		end
 
 		if not branches or #branches == 0 then
-			utils.notify(
-				"No branches found",
-				vim.log.levels.WARN
-			)
+			utils.notify("No branches found", vim.log.levels.WARN)
 			return
 		end
 
-		local items = {}
+		local filtered = {}
 		for _, branch in ipairs(branches) do
 			if not branch.name:match("/HEAD$") then
-				items[#items + 1] = { name = branch.name }
+				filtered[#filtered + 1] = branch
 			end
 		end
 
@@ -363,33 +691,7 @@ function M.show_base_picker()
 			if not is_active_picker_request(request_id) then
 				return
 			end
-
-			list_picker.open({
-				items = items,
-				title = "Select Rebase Base",
-				multi_select = false,
-				on_submit = function(selected)
-					if not is_active_picker_request(request_id) then
-						return
-					end
-
-					if #selected > 0 then
-						next_picker_request_id()
-						M.state.base_ref = selected[1]
-						M.state.stage = "todo"
-						M.refresh()
-					end
-				end,
-				on_cancel = function()
-					if not is_active_picker_request(request_id) then
-						return
-					end
-
-					if M.state.stage == "base" then
-						M.close()
-					end
-				end,
-			})
+			render_base_picker(filtered)
 		end)
 	end)
 end
@@ -481,13 +783,16 @@ function M.move_down()
 	end
 	local entries = M.state.entries
 	entries[idx], entries[idx + 1] = entries[idx + 1], entries[idx]
+	local cur = vim.api.nvim_win_get_cursor(M.state.winid or 0)
 	render_todo()
-	-- Move cursor down to follow the entry
+	-- Each card is 2 lines; step down by 2 to follow the moved entry.
 	if M.state.winid and vim.api.nvim_win_is_valid(M.state.winid) then
-		local cur = vim.api.nvim_win_get_cursor(M.state.winid)
-		vim.api.nvim_win_set_cursor(
-			M.state.winid, { cur[1] + 1, cur[2] }
+		local new_line = math.min(
+			cur[1] + 2,
+			vim.api.nvim_buf_line_count(M.state.bufnr or 0)
 		)
+		vim.api.nvim_win_set_cursor(M.state.winid, { new_line, cur[2] })
+		M.state.focused_line = new_line
 	end
 end
 
@@ -502,13 +807,13 @@ function M.move_up()
 	end
 	local entries = M.state.entries
 	entries[idx], entries[idx - 1] = entries[idx - 1], entries[idx]
+	local cur = vim.api.nvim_win_get_cursor(M.state.winid or 0)
 	render_todo()
-	-- Move cursor up to follow the entry
+	-- Each card is 2 lines; step up by 2 to follow the moved entry.
 	if M.state.winid and vim.api.nvim_win_is_valid(M.state.winid) then
-		local cur = vim.api.nvim_win_get_cursor(M.state.winid)
-		vim.api.nvim_win_set_cursor(
-			M.state.winid, { cur[1] - 1, cur[2] }
-		)
+		local new_line = math.max(cur[1] - 2, 1)
+		vim.api.nvim_win_set_cursor(M.state.winid, { new_line, cur[2] })
+		M.state.focused_line = new_line
 	end
 end
 
@@ -598,6 +903,23 @@ function M.close()
 	next_picker_request_id()
 	next_refresh_request_id()
 
+	if M.state.preview_winid
+		and vim.api.nvim_win_is_valid(M.state.preview_winid)
+	then
+		vim.api.nvim_win_close(M.state.preview_winid, true)
+		M.state.preview_winid = nil
+	end
+	if M.state.preview_bufnr
+		and vim.api.nvim_buf_is_valid(M.state.preview_bufnr)
+	then
+		pcall(
+			vim.api.nvim_buf_delete,
+			M.state.preview_bufnr,
+			{ force = true }
+		)
+		M.state.preview_bufnr = nil
+	end
+
 	if M.state.winid then
 		ui.window.close(M.state.winid)
 	else
@@ -617,6 +939,8 @@ function M.close()
 	M.state.base_ref = nil
 	M.state.current_branch = nil
 	M.state.stage = "base"
+	M.state.focused_line = nil
+	M.state.base_line_branches = {}
 end
 
 ---@return boolean

--- a/lua/gitflow/panels/rebase.lua
+++ b/lua/gitflow/panels/rebase.lua
@@ -27,6 +27,14 @@ local REBASE_FLOAT_TITLE = "Gitflow Interactive Rebase"
 local REBASE_FLOAT_FOOTER =
 	" <CR> cycle · p/r/e/s/f/d actions · J/K move · X execute"
 		.. " · b base · q close "
+-- Compact in-buffer hints for split layout (floats use the footer above).
+local REBASE_HINTS = {
+	{ "<CR>", "cycle action" },
+	{ "J/K", "move" },
+	{ "X", "execute" },
+	{ "b", "base" },
+	{ "q", "close" },
+}
 local REBASE_HIGHLIGHT_NS =
 	vim.api.nvim_create_namespace("gitflow_rebase_hl")
 
@@ -276,6 +284,8 @@ local function render_todo()
 			line_entries[line_no] = entry
 		end
 	end
+
+	components.split_hint_bar(B, render_opts, REBASE_HINTS)
 
 	ui.buffer.update("rebase", B.lines)
 	M.state.line_entries = line_entries

--- a/lua/gitflow/panels/review.lua
+++ b/lua/gitflow/panels/review.lua
@@ -95,6 +95,8 @@ M.state = {
 	file_list_bufnr = nil,
 	diff_winid = nil,
 	files = {},
+	files_loaded = false,
+	files_error = nil,
 	file_diffs = {},
 	comment_threads = {},
 	pending_comments = {},
@@ -666,7 +668,19 @@ local function render_file_list()
 
 	local file_lines_start = #lines + 1
 	if #M.state.files == 0 then
-		if M.state.files_loaded then
+		if M.state.files_error then
+			lines[#lines + 1] =
+				("  %s  Could not load changed files"):format(icons.get("ui", "error"))
+			ctx.highlights[#ctx.highlights + 1] = {
+				line = #lines - 1, col_start = 0, col_end = -1, hl = "GitflowStateError",
+			}
+			for _, detail in ipairs(vim.split(M.state.files_error, "\n", { plain = true })) do
+				lines[#lines + 1] = "     " .. detail
+				ctx.highlights[#ctx.highlights + 1] = {
+					line = #lines - 1, col_start = 0, col_end = -1, hl = "GitflowStateErrorDetail",
+				}
+			end
+		elseif M.state.files_loaded then
 			lines[#lines + 1] = ("  %s  No changed files"):format(icons.get("ui", "empty"))
 			ctx.highlights[#ctx.highlights + 1] = {
 				line = #lines - 1, col_start = 0, col_end = -1, hl = "GitflowReviewHint",
@@ -1657,6 +1671,7 @@ function M.refresh()
 	end
 	local number = M.state.pr_number
 
+	M.state.files_error = nil
 	M.state.pr_title = M.state.pr_title or "(loading)"
 	render_file_list()
 
@@ -1700,6 +1715,8 @@ function M.refresh()
 			local s = M.state.commit_scope
 			build_commit_scope_diffs(s.base, s.head, function(derr)
 				if derr then
+					M.state.files_loaded = true
+					M.state.files_error = derr
 					notify_error(derr)
 				end
 				load_comments_and_finish()
@@ -1709,6 +1726,8 @@ function M.refresh()
 
 		gh_prs.list_files(number, {}, function(files_err, files_data)
 			if files_err then
+				M.state.files_loaded = true
+				M.state.files_error = files_err
 				notify_error(
 					"Could not load PR files list: " .. files_err
 				)
@@ -1878,6 +1897,7 @@ function M.open(cfg, pr_number)
 	M.state.pr_base = nil
 	M.state.files = {}
 	M.state.files_loaded = false
+	M.state.files_error = nil
 	M.state.file_diffs = {}
 	M.state.comment_threads = {}
 	M.state.pending_comments = {}
@@ -1967,6 +1987,7 @@ function M.close()
 	M.state.diff_winid = nil
 	M.state.files = {}
 	M.state.files_loaded = false
+	M.state.files_error = nil
 	M.state.file_diffs = {}
 	M.state.comment_threads = {}
 	M.state.pending_comments = {}

--- a/lua/gitflow/panels/review.lua
+++ b/lua/gitflow/panels/review.lua
@@ -15,6 +15,7 @@ local gh_prs = require("gitflow.gh.prs")
 local git_branch = require("gitflow.git.branch")
 local inline = require("gitflow.review.inline")
 local cache = require("gitflow.review.cache")
+local icons = require("gitflow.icons")
 
 ---@class GitflowPrReviewFile
 ---@field path string
@@ -623,11 +624,13 @@ local function render_file_list()
 	local lines = { (" PR REVIEW · #%s"):format(n), (" %s"):format(title) }
 	local header_lines = 2
 	if M.state.pr_author then
-		lines[#lines + 1] = ("  by @%s"):format(M.state.pr_author)
+		lines[#lines + 1] = ("  %s @%s"):format(
+			icons.get("ui", "author"), M.state.pr_author
+		)
 	end
 	if M.state.pr_head and M.state.pr_base then
-		lines[#lines + 1] = ("  %s ← %s"):format(
-			M.state.pr_base, M.state.pr_head
+		lines[#lines + 1] = ("  %s %s ← %s"):format(
+			icons.get("branch", "current"), M.state.pr_base, M.state.pr_head
 		)
 	end
 	if M.state.commit_scope and M.state.commit_scope.label then
@@ -663,7 +666,22 @@ local function render_file_list()
 
 	local file_lines_start = #lines + 1
 	if #M.state.files == 0 then
-		lines[#lines + 1] = "  (no files)"
+		if M.state.files_loaded then
+			lines[#lines + 1] = ("  %s  No changed files"):format(icons.get("ui", "empty"))
+			ctx.highlights[#ctx.highlights + 1] = {
+				line = #lines - 1, col_start = 0, col_end = -1, hl = "GitflowReviewHint",
+			}
+			lines[#lines + 1] = "     Nothing to review in this PR."
+			ctx.highlights[#ctx.highlights + 1] = {
+				line = #lines - 1, col_start = 0, col_end = -1, hl = "GitflowReviewHint",
+			}
+		else
+			lines[#lines + 1] =
+				("  %s  Loading changed files…"):format(icons.get("ui", "loading"))
+			ctx.highlights[#ctx.highlights + 1] = {
+				line = #lines - 1, col_start = 0, col_end = -1, hl = "GitflowLoadingText",
+			}
+		end
 	else
 		render_tree_node(build_file_tree(M.state.files), 0, "", ctx)
 	end
@@ -714,25 +732,71 @@ local function render_file_list()
 
 	lines[#lines + 1] = ""
 	lines[#lines + 1] = sep
-	local hints = {
-		" ~ mod  + add  - del  > ren",
-		" [n] threads  ●n drafts",
-		" <CR>/o open · <Tab> fold",
-		" zR/zM  unfold/fold all",
-		" c comment (file/line/del)",
-		" S submit · C scope commits",
-		" R reply · <leader>e edit",
-		" <leader>d toggle diff view",
-		" <leader>x delete comment",
-		" ]f/[f file · ]c/[c hunk",
-		" on draft: <CR> jump · dd del",
-		" e edit draft/file · X off-diff",
-		" r refresh · q close",
-	}
-	local hint_start = #lines + 1
-	for _, h in ipairs(hints) do
-		lines[#lines + 1] = h
+
+	-- Grouped, styled key hints. Each group carries an accent label and every
+	-- key is highlighted distinctly from its description, so the legend reads as
+	-- scannable sections rather than a flat wall of identical grey text.
+	local hint_spans = {}
+	local function push_hint(text, spans)
+		lines[#lines + 1] = text
+		if spans and #spans > 0 then
+			hint_spans[#lines] = spans
+		end
 	end
+	local function hint_label(label)
+		push_hint(" " .. label, { { 1, 1 + #label, "GitflowHintGroupLabel" } })
+	end
+	local function hint_chunks_line(chunks)
+		local s, spans = join_chunks(chunks)
+		local conv = {}
+		for _, sp in ipairs(spans) do
+			conv[#conv + 1] = { sp.col_start, sp.col_end, sp.hl }
+		end
+		push_hint(s, conv)
+	end
+	local function hint_keys(pairs)
+		local chunks = { { "   ", nil } }
+		for i, p in ipairs(pairs) do
+			if i > 1 then
+				chunks[#chunks + 1] = { "   ", "GitflowReviewHint" }
+			end
+			chunks[#chunks + 1] = { p[1], "GitflowHintKey" }
+			chunks[#chunks + 1] = { " " .. p[2], "GitflowReviewHint" }
+		end
+		hint_chunks_line(chunks)
+	end
+
+	hint_label("LEGEND")
+	hint_chunks_line({
+		{ "   ", nil },
+		{ "~", "GitflowModified" }, { " mod  ", "GitflowReviewHint" },
+		{ "+", "GitflowAdded" }, { " add  ", "GitflowReviewHint" },
+		{ "-", "GitflowRemoved" }, { " del  ", "GitflowReviewHint" },
+		{ ">", "GitflowChip" }, { " ren", "GitflowReviewHint" },
+	})
+	hint_chunks_line({
+		{ "   ", nil },
+		{ "[n]", "GitflowReviewCountAdd" }, { " threads   ", "GitflowReviewHint" },
+		{ "●n", "GitflowReviewDraftBox" }, { " drafts", "GitflowReviewHint" },
+	})
+
+	hint_label("NAVIGATE")
+	hint_keys({ { "<CR>/o", "open" }, { "<Tab>", "fold" } })
+	hint_keys({ { "zR/zM", "unfold/fold all" } })
+	hint_keys({ { "]f/[f", "file" }, { "]c/[c", "hunk" } })
+
+	hint_label("REVIEW")
+	hint_keys({ { "c", "comment" }, { "R", "reply" } })
+	hint_keys({ { "S", "submit" }, { "C", "scope" } })
+	hint_keys({ { "<leader>e", "edit" }, { "<leader>x", "delete" } })
+	hint_keys({ { "<leader>d", "toggle diff view" } })
+
+	hint_label("DRAFTS")
+	hint_keys({ { "<CR>", "jump" }, { "dd", "delete" } })
+	hint_keys({ { "e", "edit/file" }, { "X", "off-diff" } })
+
+	lines[#lines + 1] = ""
+	hint_keys({ { "r", "refresh" }, { "q", "close" } })
 
 	vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
@@ -756,9 +820,11 @@ local function render_file_list()
 	for _, sp in ipairs(ctx.highlights) do
 		hl(sp.line, sp.col_start, sp.col_end, sp.hl)
 	end
-	-- Footer hints.
-	for i = 0, #hints - 1 do
-		hl(hint_start - 1 + i, 0, -1, "GitflowReviewHint")
+	-- Footer hints (grouped labels + per-key styling).
+	for line1, spans in pairs(hint_spans) do
+		for _, sp in ipairs(spans) do
+			hl(line1 - 1, sp[1], sp[2], sp[3])
+		end
 	end
 	-- Drafts section spans.
 	for line1, group in pairs(draft_hl) do
@@ -1403,6 +1469,7 @@ local function pull_pr_metadata(view)
 		end
 		if #files > 0 then
 			M.state.files = files
+			M.state.files_loaded = true
 		end
 	end
 end
@@ -1466,6 +1533,7 @@ local function ingest_pr_files(files_data)
 	end
 
 	M.state.files = files
+	M.state.files_loaded = true
 	M.state.file_diffs = file_diffs
 	M.state.file_markers = file_markers
 	M.state.hunk_markers = hunk_markers
@@ -1576,6 +1644,7 @@ local function build_commit_scope_diffs(base, head, cb)
 			end
 			table.sort(files, function(a, b) return a.path < b.path end)
 			M.state.files = files
+			M.state.files_loaded = true
 			M.state.file_diffs = file_diffs
 			cb(nil)
 		end
@@ -1808,6 +1877,7 @@ function M.open(cfg, pr_number)
 	M.state.pr_head_sha = nil
 	M.state.pr_base = nil
 	M.state.files = {}
+	M.state.files_loaded = false
 	M.state.file_diffs = {}
 	M.state.comment_threads = {}
 	M.state.pending_comments = {}
@@ -1896,6 +1966,7 @@ function M.close()
 	M.state.file_list_bufnr = nil
 	M.state.diff_winid = nil
 	M.state.files = {}
+	M.state.files_loaded = false
 	M.state.file_diffs = {}
 	M.state.comment_threads = {}
 	M.state.pending_comments = {}

--- a/lua/gitflow/panels/status.lua
+++ b/lua/gitflow/panels/status.lua
@@ -45,6 +45,17 @@ local STATUS_FLOAT_TITLE = "  Gitflow Status  "
 local STATUS_NO_UPSTREAM_HEADER = "Outgoing / Incoming"
 local STATUS_FLOAT_FOOTER = " s/u stage · V then s/u batch · a/A all · cc commit"
 	.. " · dd diff · cx conflict · p push · r refresh · q close "
+-- Compact in-buffer hints for split layout (floats use the footer above).
+local STATUS_HINTS = {
+	{ "s/u", "stage/unstage" },
+	{ "a/A", "all" },
+	{ "<CR>", "open" },
+	{ "cc", "commit" },
+	{ "dd", "diff" },
+	{ "p", "push" },
+	{ "r", "refresh" },
+	{ "q", "close" },
+}
 
 ---@type GitflowStatusPanelState
 M.state = {
@@ -239,7 +250,7 @@ local function ensure_window(cfg)
 	if not bufnr then
 		bufnr = ui.buffer.create("status", {
 			filetype = "gitflowstatus",
-			lines = { "Loading git status..." },
+			lines = components.loading_lines("Loading git status…"),
 		})
 		M.state.bufnr = bufnr
 	end
@@ -432,6 +443,11 @@ local function render(grouped, outgoing_entries, incoming_entries, upstream_name
 		components.empty(B, "No upstream branch — push will set it automatically")
 		B:blank()
 	end
+
+	-- In-buffer hints for split layout (floats advertise the same keys in their
+	-- window footer). Kept above the branch footer so the final line stays the
+	-- exact "Current branch: <branch>" string other panels/tests rely on.
+	components.split_hint_bar(B, render_opts, STATUS_HINTS)
 
 	-- Final line must be exactly "Current branch: <branch>".
 	components.branch_footer(B, current_branch)

--- a/lua/gitflow/panels/worktree.lua
+++ b/lua/gitflow/panels/worktree.lua
@@ -18,6 +18,16 @@ local WORKTREE_FLOAT_TITLE = "  Gitflow Worktrees  "
 local WORKTREE_FLOAT_FOOTER =
 	" a add · d/D remove · m move · L lock · p prune"
 	.. " · <CR> switch · r refresh · q close "
+local WORKTREE_HINTS = {
+	{ "<CR>", "switch" },
+	{ "a", "add" },
+	{ "d/D", "remove" },
+	{ "m", "move" },
+	{ "L", "lock" },
+	{ "p", "prune" },
+	{ "r", "refresh" },
+	{ "q", "close" },
+}
 local WORKTREE_HIGHLIGHT_NS =
 	vim.api.nvim_create_namespace("gitflow_worktree_hl")
 local WORKTREE_AUGROUP =
@@ -57,7 +67,7 @@ local function ensure_window(cfg)
 	if not bufnr then
 		bufnr = ui.buffer.create("worktree", {
 			filetype = "gitflowworktree",
-			lines = { "Loading worktrees..." },
+			lines = components.loading_lines("Loading worktrees…"),
 		})
 		M.state.bufnr = bufnr
 	end
@@ -155,6 +165,40 @@ local function entry_ref(entry)
 	return "(unknown)"
 end
 
+---Paint the buffer with a single styled state block (loading / error) sharing
+---the rendered panel's header chrome so transitions don't flicker.
+---@param paint fun(B: GitflowRenderBuilder)
+local function render_state(paint)
+	local render_opts = { bufnr = M.state.bufnr, winid = M.state.winid }
+	local B = ui_render.builder()
+	components.header(B, "Gitflow Worktrees", render_opts)
+	B:blank()
+	paint(B)
+	ui.buffer.update("worktree", B.lines)
+	M.state.line_entries = {}
+	local bufnr = M.state.bufnr
+	if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+		return
+	end
+	B:apply(bufnr, WORKTREE_HIGHLIGHT_NS)
+end
+
+local function render_loading()
+	render_state(function(B)
+		components.loading(B, "Loading worktrees…")
+	end)
+end
+
+---@param message string
+local function render_error(message)
+	render_state(function(B)
+		components.error_state(B, "Could not list worktrees", {
+			detail = message,
+			hint = "Press r to retry · q to close",
+		})
+	end)
+end
+
 ---@param entries GitflowWorktreeEntry[]
 local function render(entries)
 	local render_opts = {
@@ -196,7 +240,9 @@ local function render(entries)
 
 	local line_entries = {}
 	if #entries == 0 then
-		components.empty(B, "no worktrees found")
+		components.empty(B, "No worktrees yet", {
+			hint = "Press a to add a worktree.",
+		})
 	else
 		for _, entry in ipairs(entries) do
 			local is_current = normalize(entry.path) == cwd
@@ -241,6 +287,8 @@ local function render(entries)
 		end
 	end
 
+	components.split_hint_bar(B, render_opts, WORKTREE_HINTS)
+
 	ui.buffer.update("worktree", B.lines)
 	M.state.line_entries = line_entries
 
@@ -267,6 +315,7 @@ end
 function M.open(cfg)
 	M.state.cfg = cfg
 	ensure_window(cfg)
+	render_loading()
 
 	-- Keep the list fresh when worktrees change via commands / other panels.
 	vim.api.nvim_clear_autocmds({ group = WORKTREE_AUGROUP })
@@ -292,6 +341,7 @@ function M.refresh()
 	git_worktree.list({}, function(err, entries)
 		if err then
 			utils.notify(err, vim.log.levels.ERROR)
+			render_error(err)
 			return
 		end
 		render(entries or {})

--- a/lua/gitflow/panels/worktree.lua
+++ b/lua/gitflow/panels/worktree.lua
@@ -1,5 +1,6 @@
 local ui = require("gitflow.ui")
 local utils = require("gitflow.utils")
+local git = require("gitflow.git")
 local git_worktree = require("gitflow.git.worktree")
 local git_branch = require("gitflow.git.branch")
 local icons = require("gitflow.icons")
@@ -7,11 +8,18 @@ local ui_render = require("gitflow.ui.render")
 local components = require("gitflow.ui.components")
 local list_picker = require("gitflow.ui.list_picker")
 
+---@class GitflowWorktreeEnrichment
+---@field subject string|nil
+---@field rel_time string|nil
+---@field is_dirty boolean
+
 ---@class GitflowWorktreePanelState
 ---@field bufnr integer|nil
 ---@field winid integer|nil
 ---@field line_entries table<integer, GitflowWorktreeEntry>
 ---@field cfg GitflowConfig|nil
+---@field enrichment table<string, GitflowWorktreeEnrichment>
+---@field enrich_gen integer
 
 local M = {}
 local WORKTREE_FLOAT_TITLE = "  Gitflow Worktrees  "
@@ -39,6 +47,8 @@ M.state = {
 	winid = nil,
 	line_entries = {},
 	cfg = nil,
+	enrichment = {},
+	enrich_gen = 0,
 }
 
 local function emit_post_operation()
@@ -199,6 +209,12 @@ local function render_error(message)
 	end)
 end
 
+---Render the worktree list. Each entry occupies 2–3 lines:
+---  Line 1 — icon + ref + status badges ([current] [locked] [prunable] ~)
+---  Line 2 — dim: short-sha · subject · rel_time · ~/path
+---  Line 3 — (optional) lock or prune reason
+---All card lines map to the entry in line_entries so actions work from
+---any line within a card. A blank line separates cards for readability.
 ---@param entries GitflowWorktreeEntry[]
 local function render(entries)
 	local render_opts = {
@@ -207,8 +223,6 @@ local function render(entries)
 	}
 	local cwd = cwd_abs()
 
-	-- Resolve the ref of the worktree we are currently sitting in for the
-	-- summary bar context.
 	local current_ref
 	for _, entry in ipairs(entries) do
 		if normalize(entry.path) == cwd then
@@ -219,7 +233,6 @@ local function render(entries)
 	local B = ui_render.builder()
 	components.header(B, "Gitflow Worktrees", render_opts)
 
-	-- Count + current-context summary bar.
 	B:push({
 		{ "  ", nil },
 		{ icons.get("branch", "current") .. "  ", "GitflowSectionIcon" },
@@ -248,10 +261,8 @@ local function render(entries)
 			local is_current = normalize(entry.path) == cwd
 			local ref = entry_ref(entry)
 			local display_path = vim.fn.fnamemodify(entry.path, ":~")
+			local enrich = M.state.enrichment[entry.path]
 
-			-- Dominant state group drives the row accent + bracket markers,
-			-- so GitflowWorktreeCurrent/Locked/Prunable land on every row that
-			-- carries that state.
 			local icon_name = is_current and "current" or "local_branch"
 			local ref_group = "GitflowChip"
 			if is_current then
@@ -262,28 +273,76 @@ local function render(entries)
 				ref_group = "GitflowWorktreeLocked"
 			end
 
-			local chunks = {
+			-- Line 1: icon + branch/ref + state badges
+			local line1_chunks = {
 				{ " ", nil },
 				{ icons.get("branch", icon_name) .. "  ", ref_group },
 				{ ref, ref_group },
-				{ "  ->  ", "GitflowMeta" },
-				{ display_path, "GitflowMeta" },
 			}
 			if is_current then
-				chunks[#chunks + 1] = { "  ", nil }
-				chunks[#chunks + 1] = { "[current]", "GitflowWorktreeCurrent" }
+				line1_chunks[#line1_chunks + 1] =
+					{ "  [current]", "GitflowWorktreeCurrent" }
 			end
 			if entry.is_locked then
-				chunks[#chunks + 1] = { "  ", nil }
-				chunks[#chunks + 1] = { "[locked]", "GitflowWorktreeLocked" }
+				line1_chunks[#line1_chunks + 1] =
+					{ "  [locked]", "GitflowWorktreeLocked" }
 			end
 			if entry.is_prunable then
-				chunks[#chunks + 1] = { "  ", nil }
-				chunks[#chunks + 1] = { "[prunable]", "GitflowWorktreePrunable" }
+				line1_chunks[#line1_chunks + 1] =
+					{ "  [prunable]", "GitflowWorktreePrunable" }
+			end
+			if enrich and enrich.is_dirty then
+				line1_chunks[#line1_chunks + 1] =
+					{ "  ~", "GitflowWorktreeDirty" }
 			end
 
-			local line_no = B:push(chunks)
-			line_entries[line_no] = entry
+			local line1 = B:push(line1_chunks)
+			line_entries[line1] = entry
+
+			-- Line 2: sha · subject · rel_time · path (dim meta row)
+			local short_sha = (entry.sha ~= "" and entry.sha:sub(1, 7)) or nil
+			local line2_chunks = { { "       ", nil } }
+
+			if entry.is_bare then
+				line2_chunks[#line2_chunks + 1] =
+					{ display_path, "GitflowMeta" }
+			else
+				if short_sha then
+					line2_chunks[#line2_chunks + 1] =
+						{ short_sha, "GitflowMeta" }
+				end
+				if enrich and enrich.subject and enrich.subject ~= "" then
+					local prefix = short_sha and "  " or ""
+					line2_chunks[#line2_chunks + 1] =
+						{ prefix .. enrich.subject, "GitflowMeta" }
+				end
+				if enrich and enrich.rel_time and enrich.rel_time ~= "" then
+					line2_chunks[#line2_chunks + 1] =
+						{ "  ·  " .. enrich.rel_time, "GitflowRelTime" }
+				end
+				line2_chunks[#line2_chunks + 1] =
+					{ "  ·  " .. display_path, "GitflowMeta" }
+			end
+
+			local line2 = B:push(line2_chunks)
+			line_entries[line2] = entry
+
+			-- Line 3 (optional): lock or prune reason
+			if entry.is_locked and entry.lock_reason then
+				local line3 = B:push({
+					{ "       Locked: ", "GitflowWorktreeLocked" },
+					{ entry.lock_reason, "GitflowMeta" },
+				})
+				line_entries[line3] = entry
+			elseif entry.is_prunable and entry.prune_reason then
+				local line3 = B:push({
+					{ "       Prunable: ", "GitflowWorktreePrunable" },
+					{ entry.prune_reason, "GitflowMeta" },
+				})
+				line_entries[line3] = entry
+			end
+
+			B:blank()
 		end
 	end
 
@@ -298,6 +357,90 @@ local function render(entries)
 	end
 	B:apply(bufnr, WORKTREE_HIGHLIGHT_NS)
 	components.cursorline(M.state.winid, true)
+end
+
+---Fire async enrichment for each non-bare worktree: commit subject + relative
+---time (one git-log call) and dirty status (git-status --porcelain). Both
+---calls are batched in parallel; a single re-render fires once ALL complete.
+---A generation counter discards results from superseded refreshes.
+---@param entries GitflowWorktreeEntry[]
+local function enrich_entries(entries)
+	local enrichable = {}
+	for _, entry in ipairs(entries) do
+		if not entry.is_bare
+			and entry.path ~= ""
+			and vim.fn.isdirectory(entry.path) == 1
+		then
+			enrichable[#enrichable + 1] = entry
+		end
+	end
+
+	if #enrichable == 0 then
+		return
+	end
+
+	M.state.enrich_gen = M.state.enrich_gen + 1
+	local gen = M.state.enrich_gen
+
+	local pending = #enrichable * 2
+	local enrichment = {}
+	for _, entry in ipairs(enrichable) do
+		enrichment[entry.path] = {}
+	end
+
+	local function done()
+		pending = pending - 1
+		if pending > 0 or gen ~= M.state.enrich_gen then
+			return
+		end
+		M.state.enrichment = enrichment
+		-- Re-render with the same entries list — card structure is stable
+		-- (same line count per entry) so cursor position is preserved.
+		if M.is_open() then
+			render(entries)
+		end
+	end
+
+	for _, entry in ipairs(enrichable) do
+		-- Commit subject + relative time in one log call.
+		git.git(
+			{ "log", "-1", "--format=%s%x1F%ar" },
+			{ cwd = entry.path },
+			function(result)
+				if result.code == 0 then
+					local out = vim.trim(result.stdout or "")
+					if out ~= "" then
+						local sep = out:find("\x1F", 1, true)
+						local subject, rel_time
+						if sep then
+							subject = out:sub(1, sep - 1)
+							rel_time = vim.trim(out:sub(sep + 1))
+						else
+							subject = out
+						end
+						-- Guard against multi-line output (e.g. test stubs).
+						enrichment[entry.path].subject =
+							subject and subject:match("^([^\n]*)")
+						enrichment[entry.path].rel_time = rel_time
+					end
+				end
+				done()
+			end
+		)
+
+		-- Dirty indicator: any output from --porcelain means uncommitted changes.
+		git.git(
+			{ "status", "--porcelain" },
+			{ cwd = entry.path },
+			function(result)
+				if result.code == 0 then
+					enrichment[entry.path].is_dirty =
+						vim.trim(result.stdout or "") ~= ""
+				end
+				done()
+			end
+		)
+	end
 end
 
 ---@return GitflowWorktreeEntry|nil
@@ -317,7 +460,6 @@ function M.open(cfg)
 	ensure_window(cfg)
 	render_loading()
 
-	-- Keep the list fresh when worktrees change via commands / other panels.
 	vim.api.nvim_clear_autocmds({ group = WORKTREE_AUGROUP })
 	vim.api.nvim_create_autocmd("User", {
 		group = WORKTREE_AUGROUP,
@@ -338,13 +480,19 @@ function M.refresh()
 		return
 	end
 
+	-- Invalidate any in-flight enrichment from the previous load.
+	M.state.enrich_gen = M.state.enrich_gen + 1
+	M.state.enrichment = {}
+
 	git_worktree.list({}, function(err, entries)
 		if err then
 			utils.notify(err, vim.log.levels.ERROR)
 			render_error(err)
 			return
 		end
-		render(entries or {})
+		local list = entries or {}
+		render(list)
+		enrich_entries(list)
 	end)
 end
 
@@ -425,7 +573,6 @@ function M.add_worktree()
 		return
 	end
 
-	-- 1) Where the worktree lives on disk.
 	ui.input.prompt(
 		{ prompt = "New worktree path: " },
 		function(path)
@@ -434,11 +581,7 @@ function M.add_worktree()
 			end
 			path = vim.trim(path)
 
-			-- 2) Pick the base ref from a searchable list of branches.
 			pick_base_ref("Base worktree on", function(base)
-				-- 3) Optionally create a new branch from that base. Leaving
-				--    the name empty checks the base ref out directly.
-				--    (<Esc> aborts — on_confirm only fires on a typed value.)
 				ui.input.prompt(
 					{
 						prompt = ("New branch name (empty = check out '%s'): ")
@@ -474,8 +617,6 @@ function M.remove_under_cursor(force)
 		return
 	end
 
-	-- A locked worktree can't be removed without force; nudge the user to
-	-- unlock (L) or force (D) rather than letting git error out.
 	if entry.is_locked and not force then
 		utils.notify(
 			"Worktree is locked — press L to unlock, or D to force-remove",
@@ -536,7 +677,6 @@ function M.toggle_lock_under_cursor()
 		return
 	end
 
-	-- Locking: offer an optional reason.
 	ui.input.prompt(
 		{ prompt = "Lock reason (optional): " },
 		function(reason)
@@ -634,8 +774,6 @@ function M.switch_under_cursor()
 		return
 	end
 
-	-- Change Neovim's working directory so subsequent gitflow operations
-	-- (which resolve the repo via cwd) target the selected worktree.
 	local ok = pcall(vim.cmd, "cd " .. vim.fn.fnameescape(entry.path))
 	if not ok then
 		utils.notify(
@@ -671,6 +809,7 @@ function M.close()
 	M.state.bufnr = nil
 	M.state.winid = nil
 	M.state.line_entries = {}
+	M.state.enrichment = {}
 end
 
 ---@return boolean

--- a/lua/gitflow/ui/components.lua
+++ b/lua/gitflow/ui/components.lua
@@ -18,6 +18,7 @@ M.pad_right = ui_render.pad_right
 M.content_width = ui_render.content_width
 M.separator = ui_render.separator
 M.is_separator = ui_render.is_separator
+M.is_floating = ui_render.is_floating
 
 ---@param value any
 ---@return string
@@ -133,12 +134,107 @@ function M.label_chunks(labels, opts)
 	return chunks
 end
 
----Push an empty-state line.
+---Push an empty-state line, optionally with a leading icon and a dim action
+---hint underneath. Called with just (B, text) it stays a single muted line so
+---existing callers and last-line invariants are unchanged.
 ---@param B GitflowRenderBuilder
 ---@param text string
+---@param opts table|nil  { icon = string, hint = string }
 ---@return integer line_no
-function M.empty(B, text)
-	return B:push({ { "   ", nil }, { text, "GitflowMeta" } })
+function M.empty(B, text, opts)
+	opts = opts or {}
+	if opts.icon == nil and opts.hint == nil then
+		return B:push({ { "   ", nil }, { text, "GitflowMeta" } })
+	end
+	local icon = opts.icon
+	if icon == nil then
+		icon = icons.get("ui", "empty")
+	end
+	local line_no = B:push({
+		{ "   ", nil },
+		{ (icon ~= "" and icon .. "  " or ""), "GitflowEmptyIcon" },
+		{ text, "GitflowEmptyText" },
+	})
+	if opts.hint and opts.hint ~= "" then
+		B:push({ { "   ", nil }, { opts.hint, "GitflowEmptyHint" } })
+	end
+	return line_no
+end
+
+---Push a styled loading state: a leading glyph plus a label, with an optional
+---dim detail line. Replaces bare "Loading…" text so every surface shows the
+---same cohesive in-progress affordance.
+---@param B GitflowRenderBuilder
+---@param label string
+---@param opts table|nil  { icon = string, detail = string, leading = string }
+---@return integer line_no
+function M.loading(B, label, opts)
+	opts = opts or {}
+	local icon = opts.icon
+	if icon == nil then
+		icon = icons.get("ui", "loading")
+	end
+	local lead = opts.leading or "  "
+	local line_no = B:push({
+		{ lead, nil },
+		{ (icon ~= "" and icon .. "  " or ""), "GitflowLoadingIcon" },
+		{ label, "GitflowLoadingText" },
+	})
+	if opts.detail and opts.detail ~= "" then
+		B:push({ { lead, nil }, { opts.detail, "GitflowEmptyHint" } })
+	end
+	return line_no
+end
+
+---Build a plain (un-highlighted) loading placeholder for buffer creation, used
+---as the brief first paint before a panel renders its highlighted content.
+---@param label string|nil
+---@return string[]
+function M.loading_lines(label)
+	return { "", "  " .. icons.get("ui", "loading") .. "  " .. (label or "Loading…") }
+end
+
+---Push a real in-buffer error state: an error glyph + message, with an optional
+---dim detail line and a retry hint. Surfaces failures inside the panel instead
+---of relying only on a transient notification.
+---@param B GitflowRenderBuilder
+---@param message string
+---@param opts table|nil  { detail = string, hint = string }
+---@return integer line_no
+function M.error_state(B, message, opts)
+	opts = opts or {}
+	local line_no = B:push({
+		{ "  ", nil },
+		{ icons.get("ui", "error") .. "  ", "GitflowStateErrorIcon" },
+		{ message, "GitflowStateError" },
+	})
+	if opts.detail and opts.detail ~= "" then
+		for _, detail_line in ipairs(vim.split(opts.detail, "\n", { plain = true })) do
+			if vim.trim(detail_line) ~= "" then
+				B:push({ { "     ", nil }, { detail_line, "GitflowStateErrorDetail" } })
+			end
+		end
+	end
+	if opts.hint and opts.hint ~= "" then
+		B:blank()
+		B:push({ { "  ", nil }, { opts.hint, "GitflowEmptyHint" } })
+	end
+	return line_no
+end
+
+---Push a grouped key-hint block: a dim group label followed by its hint pairs
+---on the next line. Keeps dense surfaces (e.g. the PR review panel) scannable
+---instead of a flat wall of hints.
+---@param B GitflowRenderBuilder
+---@param label string
+---@param pairs table[]  list of { key, label }
+---@return integer line_no
+function M.hint_group(B, label, pairs)
+	B:push({
+		{ "  ", nil },
+		{ label, "GitflowHintGroupLabel" },
+	})
+	return B:push(ui_render.hint_chunks(pairs, { leading = "    " }))
 end
 
 ---Push a styled inline key-hint bar.
@@ -150,6 +246,26 @@ function M.hint_bar(B, pairs, opts)
 	return B:push(ui_render.hint_chunks(pairs, vim.tbl_extend(
 		"force", { leading = " " }, opts or {}
 	)))
+end
+
+---Push an in-buffer key-hint bar, but only when the panel is an inline split.
+---Floats already advertise the same keys in their window footer, so showing a
+---second bar inside the buffer would be redundant; splits otherwise have no
+---hint chrome at all. This keeps discoverability symmetric across layouts.
+---@param B GitflowRenderBuilder
+---@param render_opts table|nil  { winid?, bufnr? }
+---@param pairs table[]  list of { key, label }
+---@param opts table|nil  { blank_before = boolean }
+---@return integer|nil line_no  nil when rendered as a float (nothing pushed)
+function M.split_hint_bar(B, render_opts, pairs, opts)
+	if M.is_floating(render_opts) then
+		return nil
+	end
+	opts = opts or {}
+	if opts.blank_before ~= false then
+		B:blank()
+	end
+	return M.hint_bar(B, pairs)
 end
 
 ---Push a final "Current branch: <branch>" footer line. Must be the LAST line

--- a/lua/gitflow/ui/render.lua
+++ b/lua/gitflow/ui/render.lua
@@ -70,6 +70,23 @@ local function resolve_fallback(explicit_fallback)
 	return DEFAULT_SEPARATOR_WIDTH
 end
 
+---Whether the panel is rendered in a floating window (vs an inline split).
+---Floats carry their key hints in the window footer chrome, so panels show an
+---in-buffer hint bar only when this returns false.
+---@param opts table|nil  { winid?, bufnr? }
+---@return boolean
+function M.is_floating(opts)
+	local winid = resolve_window_id(opts)
+	if not winid then
+		return false
+	end
+	local ok, config = pcall(vim.api.nvim_win_get_config, winid)
+	if not ok or type(config) ~= "table" then
+		return false
+	end
+	return config.relative ~= nil and config.relative ~= ""
+end
+
 ---Resolve content width for a panel buffer/window.
 ---@param opts table|nil  { winid?, bufnr?, fallback?, min_width? }
 ---@return integer

--- a/scripts/test_stage6.lua
+++ b/scripts/test_stage6.lua
@@ -332,7 +332,7 @@ wait_until(function()
 	end
 	local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 	return find_line(lines, "Gitflow Conflicts") ~= nil
-		and find_line(lines, "Active operation: merge") ~= nil
+		and find_line(lines, "merge in progress") ~= nil
 		and find_line(lines, "choose-local.txt") ~= nil
 		and find_line(lines, "choose-base.txt") ~= nil
 		and find_line(lines, "choose-remote.txt") ~= nil
@@ -457,7 +457,7 @@ end
 
 wait_until(function()
 	local lines = vim.api.nvim_buf_get_lines(conflict_buf, 0, -1, false)
-	return find_line(lines, "Unresolved files: 0") ~= nil
+	return find_line(lines, "all resolved") ~= nil
 end, "conflict panel should refresh when all files are resolved", 10000)
 
 wait_until(function()

--- a/scripts/test_state_components.lua
+++ b/scripts/test_state_components.lua
@@ -1,0 +1,183 @@
+-- Tests for the shared state-feedback components introduced in the second
+-- UI/UX overhaul: styled loading / error / empty states, grouped hint blocks,
+-- split-only hint bars, and the float-detection helper they build on.
+
+local script_path = debug.getinfo(1, "S").source:sub(2)
+local project_root = vim.fn.fnamemodify(script_path, ":p:h:h")
+vim.opt.runtimepath:append(project_root)
+
+local passed, total = 0, 0
+local function assert_true(cond, msg)
+	total = total + 1
+	if not cond then
+		error(msg, 2)
+	end
+	passed = passed + 1
+end
+local function assert_equals(actual, expected, msg)
+	total = total + 1
+	if actual ~= expected then
+		error(("%s (expected=%s, actual=%s)"):format(
+			msg, vim.inspect(expected), vim.inspect(actual)
+		), 2)
+	end
+	passed = passed + 1
+end
+
+local function line_has_group(B, line_no, group)
+	for _, span in ipairs(B.spans[line_no] or {}) do
+		if span[3] == group then
+			return true
+		end
+	end
+	return false
+end
+
+local icons = require("gitflow.icons")
+icons.setup({ icons = { enable = true } })
+local highlights = require("gitflow.highlights")
+highlights.setup({})
+local ui_render = require("gitflow.ui.render")
+local components = require("gitflow.ui.components")
+
+-- ── empty() backward compatibility (no opts → single muted line) ──────
+do
+	local B = ui_render.builder()
+	local n = components.empty(B, "nothing here")
+	assert_equals(#B.lines, 1, "empty() with no opts should push exactly one line")
+	assert_equals(n, 1, "empty() should return the pushed line number")
+	assert_true(B.lines[1]:find("nothing here", 1, true) ~= nil,
+		"empty() line should contain the text")
+	assert_true(line_has_group(B, 1, "GitflowMeta"),
+		"plain empty() should keep the GitflowMeta styling")
+end
+
+-- ── empty() with icon + hint → two lines, styled ─────────────────────
+do
+	local B = ui_render.builder()
+	components.empty(B, "No worktrees yet", { hint = "Press a to add a worktree." })
+	assert_equals(#B.lines, 2, "empty() with hint should push text + hint lines")
+	assert_true(line_has_group(B, 1, "GitflowEmptyIcon"),
+		"enriched empty() should style the leading icon")
+	assert_true(line_has_group(B, 1, "GitflowEmptyText"),
+		"enriched empty() should style the text")
+	assert_true(line_has_group(B, 2, "GitflowEmptyHint"),
+		"enriched empty() should style the hint")
+	assert_true(B.lines[2]:find("Press a", 1, true) ~= nil,
+		"hint line should carry the affordance text")
+end
+
+-- ── loading() → icon + label, optional detail ────────────────────────
+do
+	local B = ui_render.builder()
+	components.loading(B, "Loading things…", { detail = "Fetching." })
+	assert_equals(#B.lines, 2, "loading() with detail should push two lines")
+	assert_true(line_has_group(B, 1, "GitflowLoadingIcon"),
+		"loading() should style its glyph with GitflowLoadingIcon")
+	assert_true(line_has_group(B, 1, "GitflowLoadingText"),
+		"loading() should style its label with GitflowLoadingText")
+	assert_true(B.lines[1]:find("Loading things", 1, true) ~= nil,
+		"loading() label should be present")
+end
+
+-- ── loading_lines() → plain placeholder for buffer creation ──────────
+do
+	local lines = components.loading_lines("Loading blame…")
+	assert_true(#lines >= 1, "loading_lines() should produce at least one line")
+	local joined = table.concat(lines, "\n")
+	assert_true(joined:find("Loading blame", 1, true) ~= nil,
+		"loading_lines() should include the label")
+end
+
+-- ── error_state() → error line + multi-line detail + hint ────────────
+do
+	local B = ui_render.builder()
+	components.error_state(B, "It broke", { detail = "line one\nline two", hint = "Press r." })
+	assert_true(line_has_group(B, 1, "GitflowStateError"),
+		"error_state() message should use GitflowStateError")
+	assert_true(line_has_group(B, 1, "GitflowStateErrorIcon"),
+		"error_state() should style its icon")
+	-- detail splits across lines; a blank line then the hint follow.
+	local found_detail, found_hint = false, false
+	for i, l in ipairs(B.lines) do
+		if l:find("line two", 1, true) and line_has_group(B, i, "GitflowStateErrorDetail") then
+			found_detail = true
+		end
+		if l:find("Press r", 1, true) and line_has_group(B, i, "GitflowEmptyHint") then
+			found_hint = true
+		end
+	end
+	assert_true(found_detail, "error_state() should render styled multi-line detail")
+	assert_true(found_hint, "error_state() should render a styled hint")
+end
+
+-- ── hint_group() → accent label line + hint chunks ───────────────────
+do
+	local B = ui_render.builder()
+	components.hint_group(B, "NAVIGATE", { { "]f", "next file" }, { "[f", "prev file" } })
+	assert_equals(#B.lines, 2, "hint_group() should push a label and a hints line")
+	assert_true(line_has_group(B, 1, "GitflowHintGroupLabel"),
+		"hint_group() label should use GitflowHintGroupLabel")
+	assert_true(line_has_group(B, 2, "GitflowHintKey"),
+		"hint_group() hints should style keys with GitflowHintKey")
+	assert_true(B.lines[2]:find("next file", 1, true) ~= nil,
+		"hint_group() should render hint labels")
+end
+
+-- ── is_floating() / split_hint_bar() ─────────────────────────────────
+do
+	-- No window context → treated as a split.
+	assert_equals(ui_render.is_floating({}), false,
+		"is_floating() should be false without a window")
+
+	local B = ui_render.builder()
+	local n = components.split_hint_bar(B, {}, { { "q", "close" } })
+	assert_true(n ~= nil, "split_hint_bar() should render in split layout")
+	assert_true(#B.lines >= 2, "split_hint_bar() should add a blank + hint line in split")
+
+	-- Float window → is_floating true, split_hint_bar suppresses output.
+	local buf = vim.api.nvim_create_buf(false, true)
+	local win = vim.api.nvim_open_win(buf, false, {
+		relative = "editor", row = 1, col = 1, width = 40, height = 6,
+		style = "minimal", border = "rounded",
+	})
+	assert_equals(ui_render.is_floating({ winid = win }), true,
+		"is_floating() should be true for a float window")
+	local B2 = ui_render.builder()
+	local n2 = components.split_hint_bar(B2, { winid = win }, { { "q", "close" } })
+	assert_equals(n2, nil, "split_hint_bar() should return nil for a float")
+	assert_equals(#B2.lines, 0, "split_hint_bar() should push nothing for a float")
+	vim.api.nvim_win_close(win, true)
+	vim.api.nvim_buf_delete(buf, { force = true })
+end
+
+-- ── highlight groups + state icons resolve ───────────────────────────
+do
+	local groups = {
+		"GitflowLoadingIcon", "GitflowLoadingText",
+		"GitflowStateError", "GitflowStateErrorIcon", "GitflowStateErrorDetail",
+		"GitflowEmptyIcon", "GitflowEmptyText", "GitflowEmptyHint",
+		"GitflowHintGroupLabel",
+	}
+	for _, g in ipairs(groups) do
+		assert_true(highlights.DEFAULT_GROUPS[g] ~= nil,
+			("%s should exist in DEFAULT_GROUPS"):format(g))
+		local hl = vim.api.nvim_get_hl(0, { name = g })
+		assert_true(hl and (hl.link or hl.fg or hl.bg) ~= nil,
+			("%s should be defined after setup"):format(g))
+	end
+
+	-- Nerd-font glyphs present when icons enabled…
+	icons.setup({ icons = { enable = true } })
+	for _, name in ipairs({ "loading", "error", "empty" }) do
+		assert_true(icons.get("ui", name) ~= "",
+			("ui icon '%s' should resolve to a glyph"):format(name))
+	end
+	-- …and a clean ASCII fallback when disabled.
+	icons.setup({ icons = { enable = false } })
+	assert_equals(icons.get("ui", "error"), "!",
+		"error icon should fall back to '!' in ascii mode")
+	icons.setup({ icons = { enable = true } })
+end
+
+print(("State component tests passed (%d/%d assertions)"):format(passed, total))

--- a/tests/e2e/gear_system_spec.lua
+++ b/tests/e2e/gear_system_spec.lua
@@ -207,7 +207,7 @@ T.run_suite("E2E: Conflict Resolution UI", {
 				"conflict panel should show conflicted file.txt"
 			)
 			T.assert_true(
-				T.find_line(lines, "Unresolved files: 1") ~= nil,
+				T.find_line(lines, "1 unresolved") ~= nil,
 				"should show 1 unresolved file"
 			)
 		end)
@@ -236,9 +236,12 @@ T.run_suite("E2E: Conflict Resolution UI", {
 
 		local bufnr = ui.buffer.get("conflict")
 		local lines = T.buf_lines(bufnr)
+		-- With no active operation the summary bar shows the idle state; when a
+		-- merge/rebase/cherry-pick is in progress it shows "<op> in progress".
 		T.assert_true(
-			T.find_line(lines, "Active operation:") ~= nil,
-			"should show active operation line"
+			T.find_line(lines, "No active operation") ~= nil
+				or T.find_line(lines, "in progress") ~= nil,
+			"should show active operation context line"
 		)
 
 		T.cleanup_panels()
@@ -254,9 +257,11 @@ T.run_suite("E2E: Conflict Resolution UI", {
 		local bufnr = ui.buffer.get("conflict")
 		T.assert_true(bufnr ~= nil, "conflict buffer should exist")
 		local lines = T.buf_lines(bufnr)
+		-- Empty state shows the resolved affordance instead of a raw count.
 		T.assert_true(
-			T.find_line(lines, "Unresolved files: 0") ~= nil,
-			"should show 0 unresolved files when no conflicts"
+			T.find_line(lines, "all resolved") ~= nil
+				or T.find_line(lines, "No conflicts") ~= nil,
+			"should show resolved/no-conflicts state when there are none"
 		)
 
 		T.cleanup_panels()

--- a/tests/e2e/rebase_spec.lua
+++ b/tests/e2e/rebase_spec.lua
@@ -87,8 +87,8 @@ T.run_suite("Interactive Rebase Panel", {
 	["parse_commits returns entries with pick default action"] = function()
 		local git_rebase = require("gitflow.git.rebase")
 		local output = table.concat({
-			"abc1234567890123456789012345678901234567\tfirst",
-			"def5678901234567890123456789012345678901\tsecond",
+			"abc1234567890123456789012345678901234567\tJohn Doe\t3 days ago\tfirst",
+			"def5678901234567890123456789012345678901\tJane Smith\t1 hour ago\tsecond",
 		}, "\n")
 		local entries = git_rebase.parse_commits(output)
 		T.assert_equals(#entries, 2, "should parse 2 entries")
@@ -99,6 +99,14 @@ T.run_suite("Interactive Rebase Panel", {
 		T.assert_equals(
 			entries[1].short_sha, "abc1234",
 			"short_sha should be 7 chars"
+		)
+		T.assert_equals(
+			entries[1].author, "John Doe",
+			"author should be parsed"
+		)
+		T.assert_equals(
+			entries[1].relative_time, "3 days ago",
+			"relative_time should be parsed"
 		)
 	end,
 


### PR DESCRIPTION
## Intent

Second, deeper UI/UX overhaul of gitflow's in-editor surfaces, on top of the existing feature/pr-and-issues-overhaul base. Goal: take the panels from good to exceptional while strictly preserving all keymap/command/Git/GitHub behavior (no keybinding or user-facing behavior changes). The cohesive theme is shared STATE FEEDBACK and IN-CONTEXT DISCOVERABILITY: every buffer-based surface previously showed bare 'Loading...' text, surfaced errors only as transient notifications, had thin '(none)' empty states, and advertised key hints ONLY in float-window footers (split-layout users saw no hints).

Foundation added to ui/components.lua + ui/render.lua + highlights.lua + icons.lua: loading()/loading_lines(), error_state(), an enriched empty(B, text, {icon, hint}) that stays backward-compatible when called with no opts, hint_group(), and split_hint_bar() which renders an in-buffer hint bar ONLY in split layout (floats keep their footer chrome) gated by the new ui_render.is_floating(). New highlight groups (GitflowLoading*, GitflowState*, GitflowEmpty*, GitflowHintGroupLabel) intentionally LINK to standard semantic groups (Comment, DiagnosticError, etc.) so they follow the user's colorscheme; new loading/error/empty state icons have clean ASCII fallbacks.

Surfaces elevated: status (styled loading + split hints, branch footer kept as last line by design since tests assert it), blame + worktree (loading/error/empty-with-affordance + split hints; deliberately kept the [current]/[locked] badges and 'detached' text tests rely on), inline blame (truncate long commit subjects to prevent overflow), PR review review.lua (the 13-line flat hint wall regrouped into accent-labelled sections with per-key styling; author/branch glyphs; a new files_loaded flag distinguishes a real loading state from a genuine empty state), conflict list panels/conflict.lua (rebuilt on the chunk builder with an operation/resolved summary bar, conflict-iconed rows, styled marker errors, loading/error states, split hints), interactive rebase (split hint bar for parity).

Intentionally NOT changed (already strong or would be a behavior change): PR/issue list panels, pickers, command palette, and the single-pane conflict resolver were already well-polished; commit and push are cmdline-prompt + notification flows where a redesign would alter user-facing behavior, so they were left as-is (push feedback already renders through the polished notifications panel).

Because presentation copy in the conflict summary changed intentionally ('Active operation: merge' -> 'merge in progress'; 'Unresolved files: N' -> 'N unresolved'/'all resolved'), I updated the corresponding assertions in tests/e2e/gear_system_spec.lua and scripts/test_stage6.lua to the new wording, keeping them meaningful. Added scripts/test_state_components.lua (51 assertions) and registered it in .github/workflows/e2e.yml. Documented the new groups in doc/gitflow.txt and created AGENTS.md with UI/testing conventions. Note: scripts/test_stage3.lua has a PRE-EXISTING failure in its branch-rename section and is intentionally not in the CI gate list. Full e2e + stage suites pass locally.

## What Changed

- Added shared state-feedback primitives to `ui/components.lua`, `ui/render.lua`, `highlights.lua`, and `icons.lua`: `loading()`/`loading_lines()`, `error_state()`, an enriched backward-compatible `empty(B, text, {icon, hint})`, `hint_group()`, and a split-only `split_hint_bar()` gated by the new `ui_render.is_floating()`; new `Gitflow{Loading,State,Empty,HintGroupLabel}*` highlight groups link to standard semantic groups with ASCII icon fallbacks.
- Elevated panels to use these: status, blame, worktree, rebase, conflict, and PR review now render styled loading/error/empty states and in-buffer hint bars in split layout (floats keep footer hints); conflict gains an operation/resolved summary bar and iconed rows, review regroups its hint wall into accent-labelled sections and adds a `files_loaded` flag distinguishing real loading from empty (and now renders an error state on file-load failure instead of looping forever), and inline blame truncates long commit subjects.
- Updated conflict-summary assertions in `gear_system_spec.lua` and `test_stage6.lua` to the new copy, added `scripts/test_state_components.lua` (registered in `e2e.yml`), and documented the new groups in `doc/gitflow.txt` plus a new `AGENTS.md`.

## Risk Assessment

✅ Low: The change is a cohesive, backward-compatible presentation-layer refactor with no keymap/behavior changes; referenced icons/highlight groups/component signatures all check out, the prior round's loading-state bug is fixed, and affected test assertions were updated to match the new copy.

## Testing

Ran the complete CI gate (all e2e specs + 23 stage tests) — everything passes, including the new state-components test and the intentionally-updated conflict-summary wording assertions. Beyond green tests, I produced reviewer-visible visual evidence by driving the real conflict panel against a genuine merge-conflict repository and by rendering the shared state-feedback helpers in a live Neovim TUI under a truecolor colorscheme, then converting the ANSI terminal captures to PNGs. The screenshots demonstrate the new summary bar, iconed conflict rows, empty-state affordances, in-buffer split hint bar, and the cohesive loading/error/empty/hint-group language following the colorscheme — matching the intent of richer state feedback and in-context discoverability with no behavior changes.

- Evidence: Conflict panel - real merge-conflict state (split layout): summary bar merge in progress / 2 unresolved, conflict-iconed file rows, styled split hint bar (local file: <code>/tmp/no-mistakes-evidence/01KW9W1XVTTMJ4XC0GM2KCT5QK/01-conflict-panel.png</code>)
- Evidence: Conflict panel - all-resolved empty state with affordance (All conflicts resolved, Press C to continue the merge or A to abort) (local file: <code>/tmp/no-mistakes-evidence/01KW9W1XVTTMJ4XC0GM2KCT5QK/02-conflict-all-resolved.png</code>)
- Evidence: Shared state-feedback helpers (real ui/components.lua output): loading, error_state with detail+retry hint, empty with affordance, hint_group accent sections, split hint bar (local file: <code>/tmp/no-mistakes-evidence/01KW9W1XVTTMJ4XC0GM2KCT5QK/03-state-feedback-helpers.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `lua/gitflow/panels/review.lua:1715` - The PR review panel now distinguishes a real loading state from an empty state via `files_loaded`, but that flag is only set on successful loads (ingest_pr_files, build_commit_scope_diffs success, pull_pr_metadata when #files&gt;0). On a load *failure* it is never set: the `gh_prs.list_files` error path calls `notify_error(...)` then `render_file_list()` (review.lua:1710-1717) without setting `files_loaded`, and `build_commit_scope_diffs` only sets it in the success callback (review.lua:1647) — its error path (result.code != 0 at 1626-1630 → derr at 1701-1706) leaves it false. Since `M.open` resets `files_loaded=false`, an initial load error renders the perpetual &#34;Loading changed files…&#34; affordance (review.lua:680) forever, even though loading has concluded with an error. Pre-change behavior showed &#34;(no files)&#34;. Set `files_loaded=true` (or render a dedicated error state) once loading concludes on the failure paths so the panel doesn&#39;t claim it&#39;s still loading.

🔧 Fix: render review file-load error state instead of perpetual loading
1 info still open:
- ℹ️ `lua/gitflow/inline_blame.lua:127` - The overflow guard checks display width (strdisplaywidth &gt; 72) but truncates by character count (strcharpart(summary, 0, 71)). For wide/CJK commit subjects these diverge: 71 double-width characters still render ~142 cells, so the annotation can still run off-screen for the exact long-subject case this code targets. For ASCII (the common case) it works correctly. If bounding actual display width matters, truncate iteratively by accumulated strdisplaywidth rather than by char count.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nvim --headless -u NONE -l scripts/test_state_components.lua`
- `nvim --headless -u NONE -l scripts/test_stage6.lua`
- `nvim --headless -u tests/minimal_init.lua -l tests/e2e/gear_system_spec.lua`
- `Full CI gate: all tests/e2e_smoke_test.lua + tests/e2e/*.lua specs and all 23 scripts/test_*.lua stage tests pass`
- `Manual: drove real gitflow.panels.conflict against a temp repo in a real merge-conflict state in split layout, captured colorized TUI screenshots of active and all-resolved states`
- `Manual: rendered shipped ui/components.lua loading/error/empty/hint_group/split_hint_bar helpers in a real Neovim buffer and captured a colorized screenshot`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
