### PR TITLE
Update to the worktree panel

### DIFF
--- a/lua/gitflow/git/rebase.lua
+++ b/lua/gitflow/git/rebase.lua
@@ -5,6 +5,8 @@ local git = require("gitflow.git")
 ---@field sha string
 ---@field short_sha string
 ---@field subject string
+---@field author string
+---@field relative_time string
 
 local M = {}
 
@@ -26,13 +28,16 @@ end
 function M.parse_commits(output)
 	local entries = {}
 	for _, line in ipairs(vim.split(output, "\n", { trimempty = true })) do
-		local sha, subject = line:match("^([0-9a-fA-F]+)\t(.*)$")
+		local sha, author, rel_time, subject =
+			line:match("^([0-9a-fA-F]+)\t([^\t]*)\t([^\t]*)\t(.*)$")
 		if sha then
 			entries[#entries + 1] = {
 				action = "pick",
 				sha = sha,
 				short_sha = sha:sub(1, 7),
 				subject = subject,
+				author = author,
+				relative_time = rel_time,
 			}
 		end
 	end
@@ -49,7 +54,7 @@ function M.list_commits(base_ref, opts, cb)
 	local count = tonumber(options.count) or 50
 	local args = {
 		"log",
-		"--pretty=format:%H\t%s",
+		"--pretty=format:%H\t%an\t%ar\t%s",
 		"--reverse",
 	}
 	if count > 0 then

--- a/lua/gitflow/highlights.lua
+++ b/lua/gitflow/highlights.lua
@@ -77,6 +77,7 @@ local function build_default_groups(palette)
 		GitflowWorktreeCurrent = { link = "GitflowBranchCurrent" },
 		GitflowWorktreeLocked = { link = "WarningMsg" },
 		GitflowWorktreePrunable = { link = "Comment" },
+		GitflowWorktreeDirty = { link = "DiagnosticWarn" },
 		-- PR state
 		GitflowPROpen = { link = "DiagnosticOk" },
 		GitflowPRMerged = { link = "Special" },

--- a/lua/gitflow/panels/rebase.lua
+++ b/lua/gitflow/panels/rebase.lua
@@ -7,7 +7,6 @@ local git_conflict = require("gitflow.git.conflict")
 local icons = require("gitflow.icons")
 local ui_render = require("gitflow.ui.render")
 local components = require("gitflow.ui.components")
-local list_picker = require("gitflow.ui.list_picker")
 local status_panel = require("gitflow.panels.status")
 
 ---@class GitflowRebasePanelState
@@ -21,18 +20,30 @@ local status_panel = require("gitflow.panels.status")
 ---@field cfg GitflowConfig|nil
 ---@field picker_request_id integer
 ---@field refresh_request_id integer
+---@field focused_line integer|nil
+---@field preview_winid integer|nil
+---@field preview_bufnr integer|nil
+---@field base_line_branches table<integer, GitflowBranchEntry>
 
 local M = {}
 local REBASE_FLOAT_TITLE = "Gitflow Interactive Rebase"
 local REBASE_FLOAT_FOOTER =
-	" <CR> cycle · p/r/e/s/f/d actions · J/K move · X execute"
-		.. " · b base · q close "
+	" <CR> cycle · p/r/e/s/f/d action · J/K move · X execute"
+		.. " · P preview · b base · q close "
 -- Compact in-buffer hints for split layout (floats use the footer above).
 local REBASE_HINTS = {
-	{ "<CR>", "cycle action" },
+	{ "<CR>", "cycle" },
+	{ "p/r/e/s/f/d", "action" },
 	{ "J/K", "move" },
 	{ "X", "execute" },
+	{ "P", "preview" },
 	{ "b", "base" },
+	{ "q", "close" },
+}
+-- Hints for the base-branch picker stage.
+local BASE_FLOAT_FOOTER = " <CR> select · q close "
+local BASE_HINTS = {
+	{ "<CR>", "select" },
 	{ "q", "close" },
 }
 local REBASE_HIGHLIGHT_NS =
@@ -41,12 +52,21 @@ local REBASE_HIGHLIGHT_NS =
 local ACTIONS = { "pick", "reword", "edit", "squash", "fixup", "drop" }
 
 local ACTION_HIGHLIGHTS = {
-	pick = "GitflowRebasePick",
+	pick   = "GitflowRebasePick",
 	reword = "GitflowRebaseReword",
-	edit = "GitflowRebaseEdit",
+	edit   = "GitflowRebaseEdit",
 	squash = "GitflowRebaseSquash",
-	fixup = "GitflowRebaseFixup",
-	drop = "GitflowRebaseDrop",
+	fixup  = "GitflowRebaseFixup",
+	drop   = "GitflowRebaseDrop",
+}
+
+local ACTION_GLYPHS = {
+	pick   = "●",
+	reword = "~",
+	edit   = "≡",
+	squash = "⊕",
+	fixup  = "⊙",
+	drop   = "✗",
 }
 
 ---@type GitflowRebasePanelState
@@ -61,6 +81,10 @@ M.state = {
 	cfg = nil,
 	picker_request_id = 0,
 	refresh_request_id = 0,
+	focused_line = nil,
+	preview_winid = nil,
+	preview_bufnr = nil,
+	base_line_branches = {},
 }
 
 local function next_picker_request_id()
@@ -114,6 +138,9 @@ local function next_action(current)
 	return "pick"
 end
 
+local render_todo           -- forward declaration; defined after ensure_window
+local refresh_float_footer  -- forward declaration; defined before render_base_picker
+
 ---@param cfg GitflowConfig
 local function ensure_window(cfg)
 	local bufnr = M.state.bufnr
@@ -125,6 +152,29 @@ local function ensure_window(cfg)
 			lines = { "Loading branches..." },
 		})
 		M.state.bufnr = bufnr
+
+		vim.api.nvim_create_autocmd("CursorMoved", {
+			buffer = bufnr,
+			callback = function()
+				if vim.api.nvim_get_current_buf() ~= bufnr then
+					return
+				end
+				local line = vim.api.nvim_win_get_cursor(0)[1]
+				if line == M.state.focused_line then
+					return
+				end
+				M.state.focused_line = line
+				if M.state.stage ~= "todo" then
+					return
+				end
+				render_todo()
+				if M.state.preview_winid
+					and vim.api.nvim_win_is_valid(M.state.preview_winid)
+				then
+					M.refresh_preview()
+				end
+			end,
+		})
 	end
 
 	vim.api.nvim_set_option_value(
@@ -148,7 +198,7 @@ local function ensure_window(cfg)
 			title = REBASE_FLOAT_TITLE,
 			title_pos = cfg.ui.float.title_pos,
 			footer = cfg.ui.float.footer
-				and REBASE_FLOAT_FOOTER or nil,
+				and BASE_FLOAT_FOOTER or nil,
 			footer_pos = cfg.ui.float.footer_pos,
 			on_close = function()
 				M.state.winid = nil
@@ -166,9 +216,13 @@ local function ensure_window(cfg)
 		})
 	end
 
-	-- Action cycling
+	-- CR routes to branch selection in "base" stage, action cycling in "todo".
 	vim.keymap.set("n", "<CR>", function()
-		M.cycle_action()
+		if M.state.stage == "base" then
+			M.select_base_branch()
+		else
+			M.cycle_action()
+		end
 	end, { buffer = bufnr, silent = true })
 
 	-- Direct action keys
@@ -215,6 +269,11 @@ local function ensure_window(cfg)
 		M.show_base_picker()
 	end, { buffer = bufnr, silent = true, nowait = true })
 
+	-- Toggle diff preview for focused commit
+	vim.keymap.set("n", "P", function()
+		M.toggle_preview()
+	end, { buffer = bufnr, silent = true, nowait = true })
+
 	-- Close
 	vim.keymap.set("n", "q", function()
 		M.close()
@@ -222,7 +281,7 @@ local function ensure_window(cfg)
 end
 
 ---Render the interactive rebase todo list.
-local function render_todo()
+render_todo = function()
 	local render_opts = {
 		bufnr = M.state.bufnr,
 		winid = M.state.winid,
@@ -250,16 +309,16 @@ local function render_todo()
 		{ current_branch, "GitflowBranchCurrent" },
 	})
 
-	-- Base ref header. The literal "Base: <ref>" text is load-bearing
-	-- (asserted by tests), so keep the key and value adjacent.
-	B:push({
-		{ "  ", nil },
-		{ base_icon .. "  ", "GitflowSectionIcon" },
-		{ "Base: ", "GitflowMetaKey" },
+	-- Base ref as a meta_row (item 4).
+	components.meta_row(B, "Base:", {
+		{ base_icon .. " ", "GitflowSectionIcon" },
 		{ M.state.base_ref or "(none)", "GitflowBranchCurrent" },
-	})
+	}, { width = 7 })
 	B:blank()
 
+	-- Snapshot the previous line_entries for the detail bar lookup below
+	-- (we update M.state.line_entries at the end of this function).
+	local prev_line_entries = M.state.line_entries
 	local line_entries = {}
 
 	components.section(B, commit_icon, ("Commits (%d)"):format(count))
@@ -269,20 +328,55 @@ local function render_todo()
 		for _, entry in ipairs(M.state.entries) do
 			local action_group = ACTION_HIGHLIGHTS[entry.action]
 				or "GitflowRebasePick"
-			-- Action left-padded to 6 cols ("pick  ") + a separator
-			-- space, keeping the "pick" + subject pairing tests rely on.
-			local action_label = ("%-6s"):format(entry.action)
-			local subject = entry.subject ~= ""
-				and ("  " .. entry.subject) or ""
-			local line_no = B:push({
-				{ " ", nil },
-				{ action_label .. " ", action_group },
+			local glyph = ACTION_GLYPHS[entry.action] or "●"
+			-- squash/fixup items are indented under their pick target
+			-- (item 6: squash/fixup chain indentation).
+			local is_chain = entry.action == "squash"
+				or entry.action == "fixup"
+			local lead = is_chain and "   " or " "
+			local lead2 = is_chain and "       " or "     "
+
+			-- Line 1: glyph badge + sha + subject (items 1 & 2).
+			local line1 = B:push({
+				{ lead, nil },
+				{ glyph .. " ", action_group },
+				{ ("%-6s"):format(entry.action) .. "  ", action_group },
 				{ commit_icon .. " ", "GitflowRebaseHash" },
 				{ entry.short_sha, "GitflowRebaseHash" },
-				{ subject, "GitflowCardTitle" },
+				{ "  " .. (entry.subject or ""), "GitflowCardTitle" },
 			})
-			line_entries[line_no] = entry
+			line_entries[line1] = entry
+
+			-- Line 2: author + relative time, dimmed (item 1).
+			local line2 = B:push({
+				{ lead2, nil },
+				{ entry.author or "", "GitflowMeta" },
+				{ " · ", "GitflowMetaKey" },
+				{ entry.relative_time or "", "GitflowMeta" },
+			})
+			line_entries[line2] = entry
 		end
+	end
+
+	-- Detail bar: shows author/time/subject for the focused commit (item 8).
+	B:blank()
+	local focused_entry = prev_line_entries
+		and prev_line_entries[M.state.focused_line]
+	if focused_entry then
+		B:push({
+			{ "  ", nil },
+			{ commit_icon .. " ", "GitflowSectionIcon" },
+			{ focused_entry.author or "", "GitflowMeta" },
+			{ " · ", "GitflowMetaKey" },
+			{ focused_entry.relative_time or "", "GitflowMeta" },
+			{ "   ", nil },
+			{ focused_entry.subject or "", "GitflowCardTitle" },
+		})
+	else
+		B:push({
+			{ "   ", nil },
+			{ "move cursor to a commit to inspect", "GitflowMeta" },
+		})
 	end
 
 	components.split_hint_bar(B, render_opts, REBASE_HINTS)
@@ -296,6 +390,7 @@ local function render_todo()
 	end
 	B:apply(bufnr, REBASE_HIGHLIGHT_NS)
 	components.cursorline(M.state.winid, true)
+	refresh_float_footer()
 end
 
 ---Find the index in M.state.entries for the entry under the cursor.
@@ -319,6 +414,241 @@ local function entry_index_under_cursor()
 	return nil
 end
 
+---@return integer|nil
+local function ensure_preview_buffer()
+	if M.state.preview_bufnr
+		and vim.api.nvim_buf_is_valid(M.state.preview_bufnr)
+	then
+		return M.state.preview_bufnr
+	end
+	local bufnr = vim.api.nvim_create_buf(false, true)
+	vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = bufnr })
+	vim.api.nvim_set_option_value("buftype", "nofile", { buf = bufnr })
+	vim.api.nvim_set_option_value("filetype", "diff", { buf = bufnr })
+	vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+	M.state.preview_bufnr = bufnr
+	return bufnr
+end
+
+---Fetch and display `git show` for the currently focused commit in the preview
+---window. No-ops when the preview buffer or focused entry is absent.
+function M.refresh_preview()
+	local entry = M.state.line_entries
+		and M.state.line_entries[M.state.focused_line]
+	local preview_bufnr = M.state.preview_bufnr
+	if not entry
+		or not preview_bufnr
+		or not vim.api.nvim_buf_is_valid(preview_bufnr)
+	then
+		return
+	end
+	git.git(
+		{ "show", "--stat", "--patch", entry.sha },
+		{},
+		function(result)
+			if not vim.api.nvim_buf_is_valid(preview_bufnr) then
+				return
+			end
+			local lines = vim.split(result.stdout or "", "\n")
+			vim.schedule(function()
+				if not vim.api.nvim_buf_is_valid(preview_bufnr) then
+					return
+				end
+				vim.api.nvim_set_option_value(
+					"modifiable", true, { buf = preview_bufnr }
+				)
+				vim.api.nvim_buf_set_lines(
+					preview_bufnr, 0, -1, false, lines
+				)
+				vim.api.nvim_set_option_value(
+					"modifiable", false, { buf = preview_bufnr }
+				)
+			end)
+		end
+	)
+end
+
+---Toggle the diff-preview float for the focused commit (item 9).
+---Opens a side float showing `git show <sha>`; pressing P again closes it.
+function M.toggle_preview()
+	if M.state.stage ~= "todo" then
+		return
+	end
+	if M.state.preview_winid
+		and vim.api.nvim_win_is_valid(M.state.preview_winid)
+	then
+		vim.api.nvim_win_close(M.state.preview_winid, true)
+		M.state.preview_winid = nil
+		return
+	end
+
+	local entry = M.state.line_entries
+		and M.state.line_entries[M.state.focused_line]
+	if not entry then
+		utils.notify("Move cursor to a commit first", vim.log.levels.WARN)
+		return
+	end
+
+	local preview_bufnr = ensure_preview_buffer()
+	local columns = vim.o.columns
+	local lines_h = vim.o.lines - vim.o.cmdheight
+	local width = math.floor(columns * 0.48)
+	local height = math.floor(lines_h * 0.72)
+	local col = math.floor(columns * 0.51)
+	local row = math.floor((lines_h - height) / 2)
+
+	local preview_winid = vim.api.nvim_open_win(preview_bufnr, false, {
+		relative = "editor",
+		style = "minimal",
+		width = width,
+		height = height,
+		row = row,
+		col = col,
+		border = "rounded",
+		title = " git show ",
+		title_pos = "center",
+		zindex = 200,
+	})
+	vim.api.nvim_set_option_value(
+		"winhighlight",
+		"NormalFloat:GitflowNormal,FloatBorder:GitflowBorder"
+			.. ",FloatTitle:GitflowTitle",
+		{ win = preview_winid }
+	)
+	M.state.preview_winid = preview_winid
+
+	vim.api.nvim_create_autocmd("WinClosed", {
+		pattern = tostring(preview_winid),
+		once = true,
+		callback = function()
+			if M.state.preview_winid == preview_winid then
+				M.state.preview_winid = nil
+			end
+			if M.state.preview_bufnr
+				and vim.api.nvim_buf_is_valid(M.state.preview_bufnr)
+			then
+				pcall(
+					vim.api.nvim_buf_delete,
+					M.state.preview_bufnr,
+					{ force = true }
+				)
+			end
+			M.state.preview_bufnr = nil
+		end,
+	})
+
+	M.refresh_preview()
+end
+
+---Update the float window footer to match the current stage (best-effort).
+refresh_float_footer = function()
+	local winid = M.state.winid
+	if not winid or not vim.api.nvim_win_is_valid(winid) then
+		return
+	end
+	if vim.fn.has("nvim-0.10") ~= 1 then
+		return
+	end
+	local win_cfg = vim.api.nvim_win_get_config(winid)
+	if not win_cfg.relative or win_cfg.relative == "" then
+		return
+	end
+	local footer = M.state.stage == "base"
+		and BASE_FLOAT_FOOTER or REBASE_FLOAT_FOOTER
+	pcall(vim.api.nvim_win_set_config, winid, {
+		footer = footer,
+		footer_pos = win_cfg.footer_pos or "center",
+	})
+end
+
+---Render the branch list into the rebase panel for the "base" picker stage.
+---@param branches GitflowBranchEntry[]
+local function render_base_picker(branches)
+	local render_opts = {
+		bufnr = M.state.bufnr,
+		winid = M.state.winid,
+	}
+	local B = ui_render.builder()
+	components.header(B, "Gitflow Interactive Rebase", render_opts)
+
+	local branch_icon = icons.get("branch", "current")
+	components.section(B, branch_icon, "Select Base Branch")
+
+	local local_entries, remote_entries = git_branch.partition(branches)
+	local base_line_branches = {}
+
+	local function append_branch_section(title, entries)
+		if #entries == 0 then
+			return
+		end
+		B:push({
+			{ "  " .. title, "GitflowSectionTitle" },
+		})
+		B:raw(
+			"  " .. string.rep("-", math.max(8, #title + 2)),
+			"GitflowSeparator"
+		)
+		for _, entry in ipairs(entries) do
+			local icon, group
+			if entry.is_current then
+				icon = icons.get("branch", "current")
+				group = "GitflowBranchCurrent"
+			elseif entry.is_remote then
+				icon = icons.get("branch", "remote")
+				group = "GitflowBranchRemote"
+			else
+				icon = icons.get("branch", "local_branch")
+				group = "GitflowCardTitle"
+			end
+			local chunks = {
+				{ "    ", nil },
+				{ (icon ~= "" and icon .. "  " or ""), group },
+				{ entry.name, group },
+			}
+			if entry.is_current then
+				chunks[#chunks + 1] = {
+					"  (current)", "GitflowMeta",
+				}
+			end
+			local line_no = B:push(chunks)
+			base_line_branches[line_no] = entry
+		end
+		B:blank()
+	end
+
+	append_branch_section("Local", local_entries)
+	append_branch_section("Remote", remote_entries)
+
+	components.split_hint_bar(B, render_opts, BASE_HINTS)
+
+	ui.buffer.update("rebase", B.lines)
+	M.state.base_line_branches = base_line_branches
+
+	local bufnr = M.state.bufnr
+	if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+		return
+	end
+	B:apply(bufnr, REBASE_HIGHLIGHT_NS)
+	components.cursorline(M.state.winid, true)
+	refresh_float_footer()
+end
+
+---Confirm the branch under the cursor as the rebase base and switch to the
+---todo view.
+function M.select_base_branch()
+	local line = vim.api.nvim_win_get_cursor(0)[1]
+	local branch = M.state.base_line_branches
+		and M.state.base_line_branches[line]
+	if not branch then
+		utils.notify("Move cursor to a branch first", vim.log.levels.WARN)
+		return
+	end
+	next_picker_request_id()
+	M.state.base_ref = branch.name
+	M.state.stage = "todo"
+	M.refresh()
+end
+
 ---@param cfg GitflowConfig
 function M.open(cfg)
 	M.state.cfg = cfg
@@ -328,12 +658,13 @@ function M.open(cfg)
 end
 
 function M.show_base_picker()
-	local cfg = M.state.cfg
-	if not cfg then
+	if not M.state.cfg then
 		return
 	end
 
+	M.state.stage = "base"
 	local request_id = next_picker_request_id()
+
 	git_branch.list({}, function(err, branches)
 		if not is_active_picker_request(request_id) then
 			return
@@ -345,17 +676,14 @@ function M.show_base_picker()
 		end
 
 		if not branches or #branches == 0 then
-			utils.notify(
-				"No branches found",
-				vim.log.levels.WARN
-			)
+			utils.notify("No branches found", vim.log.levels.WARN)
 			return
 		end
 
-		local items = {}
+		local filtered = {}
 		for _, branch in ipairs(branches) do
 			if not branch.name:match("/HEAD$") then
-				items[#items + 1] = { name = branch.name }
+				filtered[#filtered + 1] = branch
 			end
 		end
 
@@ -363,33 +691,7 @@ function M.show_base_picker()
 			if not is_active_picker_request(request_id) then
 				return
 			end
-
-			list_picker.open({
-				items = items,
-				title = "Select Rebase Base",
-				multi_select = false,
-				on_submit = function(selected)
-					if not is_active_picker_request(request_id) then
-						return
-					end
-
-					if #selected > 0 then
-						next_picker_request_id()
-						M.state.base_ref = selected[1]
-						M.state.stage = "todo"
-						M.refresh()
-					end
-				end,
-				on_cancel = function()
-					if not is_active_picker_request(request_id) then
-						return
-					end
-
-					if M.state.stage == "base" then
-						M.close()
-					end
-				end,
-			})
+			render_base_picker(filtered)
 		end)
 	end)
 end
@@ -481,13 +783,16 @@ function M.move_down()
 	end
 	local entries = M.state.entries
 	entries[idx], entries[idx + 1] = entries[idx + 1], entries[idx]
+	local cur = vim.api.nvim_win_get_cursor(M.state.winid or 0)
 	render_todo()
-	-- Move cursor down to follow the entry
+	-- Each card is 2 lines; step down by 2 to follow the moved entry.
 	if M.state.winid and vim.api.nvim_win_is_valid(M.state.winid) then
-		local cur = vim.api.nvim_win_get_cursor(M.state.winid)
-		vim.api.nvim_win_set_cursor(
-			M.state.winid, { cur[1] + 1, cur[2] }
+		local new_line = math.min(
+			cur[1] + 2,
+			vim.api.nvim_buf_line_count(M.state.bufnr or 0)
 		)
+		vim.api.nvim_win_set_cursor(M.state.winid, { new_line, cur[2] })
+		M.state.focused_line = new_line
 	end
 end
 
@@ -502,13 +807,13 @@ function M.move_up()
 	end
 	local entries = M.state.entries
 	entries[idx], entries[idx - 1] = entries[idx - 1], entries[idx]
+	local cur = vim.api.nvim_win_get_cursor(M.state.winid or 0)
 	render_todo()
-	-- Move cursor up to follow the entry
+	-- Each card is 2 lines; step up by 2 to follow the moved entry.
 	if M.state.winid and vim.api.nvim_win_is_valid(M.state.winid) then
-		local cur = vim.api.nvim_win_get_cursor(M.state.winid)
-		vim.api.nvim_win_set_cursor(
-			M.state.winid, { cur[1] - 1, cur[2] }
-		)
+		local new_line = math.max(cur[1] - 2, 1)
+		vim.api.nvim_win_set_cursor(M.state.winid, { new_line, cur[2] })
+		M.state.focused_line = new_line
 	end
 end
 
@@ -598,6 +903,23 @@ function M.close()
 	next_picker_request_id()
 	next_refresh_request_id()
 
+	if M.state.preview_winid
+		and vim.api.nvim_win_is_valid(M.state.preview_winid)
+	then
+		vim.api.nvim_win_close(M.state.preview_winid, true)
+		M.state.preview_winid = nil
+	end
+	if M.state.preview_bufnr
+		and vim.api.nvim_buf_is_valid(M.state.preview_bufnr)
+	then
+		pcall(
+			vim.api.nvim_buf_delete,
+			M.state.preview_bufnr,
+			{ force = true }
+		)
+		M.state.preview_bufnr = nil
+	end
+
 	if M.state.winid then
 		ui.window.close(M.state.winid)
 	else
@@ -617,6 +939,8 @@ function M.close()
 	M.state.base_ref = nil
 	M.state.current_branch = nil
 	M.state.stage = "base"
+	M.state.focused_line = nil
+	M.state.base_line_branches = {}
 end
 
 ---@return boolean

--- a/lua/gitflow/panels/worktree.lua
+++ b/lua/gitflow/panels/worktree.lua
@@ -1,5 +1,6 @@
 local ui = require("gitflow.ui")
 local utils = require("gitflow.utils")
+local git = require("gitflow.git")
 local git_worktree = require("gitflow.git.worktree")
 local git_branch = require("gitflow.git.branch")
 local icons = require("gitflow.icons")
@@ -7,11 +8,18 @@ local ui_render = require("gitflow.ui.render")
 local components = require("gitflow.ui.components")
 local list_picker = require("gitflow.ui.list_picker")
 
+---@class GitflowWorktreeEnrichment
+---@field subject string|nil
+---@field rel_time string|nil
+---@field is_dirty boolean
+
 ---@class GitflowWorktreePanelState
 ---@field bufnr integer|nil
 ---@field winid integer|nil
 ---@field line_entries table<integer, GitflowWorktreeEntry>
 ---@field cfg GitflowConfig|nil
+---@field enrichment table<string, GitflowWorktreeEnrichment>
+---@field enrich_gen integer
 
 local M = {}
 local WORKTREE_FLOAT_TITLE = "  Gitflow Worktrees  "
@@ -39,6 +47,8 @@ M.state = {
 	winid = nil,
 	line_entries = {},
 	cfg = nil,
+	enrichment = {},
+	enrich_gen = 0,
 }
 
 local function emit_post_operation()
@@ -199,6 +209,12 @@ local function render_error(message)
 	end)
 end
 
+---Render the worktree list. Each entry occupies 2–3 lines:
+---  Line 1 — icon + ref + status badges ([current] [locked] [prunable] ~)
+---  Line 2 — dim: short-sha · subject · rel_time · ~/path
+---  Line 3 — (optional) lock or prune reason
+---All card lines map to the entry in line_entries so actions work from
+---any line within a card. A blank line separates cards for readability.
 ---@param entries GitflowWorktreeEntry[]
 local function render(entries)
 	local render_opts = {
@@ -207,8 +223,6 @@ local function render(entries)
 	}
 	local cwd = cwd_abs()
 
-	-- Resolve the ref of the worktree we are currently sitting in for the
-	-- summary bar context.
 	local current_ref
 	for _, entry in ipairs(entries) do
 		if normalize(entry.path) == cwd then
@@ -219,7 +233,6 @@ local function render(entries)
 	local B = ui_render.builder()
 	components.header(B, "Gitflow Worktrees", render_opts)
 
-	-- Count + current-context summary bar.
 	B:push({
 		{ "  ", nil },
 		{ icons.get("branch", "current") .. "  ", "GitflowSectionIcon" },
@@ -248,10 +261,8 @@ local function render(entries)
 			local is_current = normalize(entry.path) == cwd
 			local ref = entry_ref(entry)
 			local display_path = vim.fn.fnamemodify(entry.path, ":~")
+			local enrich = M.state.enrichment[entry.path]
 
-			-- Dominant state group drives the row accent + bracket markers,
-			-- so GitflowWorktreeCurrent/Locked/Prunable land on every row that
-			-- carries that state.
 			local icon_name = is_current and "current" or "local_branch"
 			local ref_group = "GitflowChip"
 			if is_current then
@@ -262,28 +273,76 @@ local function render(entries)
 				ref_group = "GitflowWorktreeLocked"
 			end
 
-			local chunks = {
+			-- Line 1: icon + branch/ref + state badges
+			local line1_chunks = {
 				{ " ", nil },
 				{ icons.get("branch", icon_name) .. "  ", ref_group },
 				{ ref, ref_group },
-				{ "  ->  ", "GitflowMeta" },
-				{ display_path, "GitflowMeta" },
 			}
 			if is_current then
-				chunks[#chunks + 1] = { "  ", nil }
-				chunks[#chunks + 1] = { "[current]", "GitflowWorktreeCurrent" }
+				line1_chunks[#line1_chunks + 1] =
+					{ "  [current]", "GitflowWorktreeCurrent" }
 			end
 			if entry.is_locked then
-				chunks[#chunks + 1] = { "  ", nil }
-				chunks[#chunks + 1] = { "[locked]", "GitflowWorktreeLocked" }
+				line1_chunks[#line1_chunks + 1] =
+					{ "  [locked]", "GitflowWorktreeLocked" }
 			end
 			if entry.is_prunable then
-				chunks[#chunks + 1] = { "  ", nil }
-				chunks[#chunks + 1] = { "[prunable]", "GitflowWorktreePrunable" }
+				line1_chunks[#line1_chunks + 1] =
+					{ "  [prunable]", "GitflowWorktreePrunable" }
+			end
+			if enrich and enrich.is_dirty then
+				line1_chunks[#line1_chunks + 1] =
+					{ "  ~", "GitflowWorktreeDirty" }
 			end
 
-			local line_no = B:push(chunks)
-			line_entries[line_no] = entry
+			local line1 = B:push(line1_chunks)
+			line_entries[line1] = entry
+
+			-- Line 2: sha · subject · rel_time · path (dim meta row)
+			local short_sha = (entry.sha ~= "" and entry.sha:sub(1, 7)) or nil
+			local line2_chunks = { { "       ", nil } }
+
+			if entry.is_bare then
+				line2_chunks[#line2_chunks + 1] =
+					{ display_path, "GitflowMeta" }
+			else
+				if short_sha then
+					line2_chunks[#line2_chunks + 1] =
+						{ short_sha, "GitflowMeta" }
+				end
+				if enrich and enrich.subject and enrich.subject ~= "" then
+					local prefix = short_sha and "  " or ""
+					line2_chunks[#line2_chunks + 1] =
+						{ prefix .. enrich.subject, "GitflowMeta" }
+				end
+				if enrich and enrich.rel_time and enrich.rel_time ~= "" then
+					line2_chunks[#line2_chunks + 1] =
+						{ "  ·  " .. enrich.rel_time, "GitflowRelTime" }
+				end
+				line2_chunks[#line2_chunks + 1] =
+					{ "  ·  " .. display_path, "GitflowMeta" }
+			end
+
+			local line2 = B:push(line2_chunks)
+			line_entries[line2] = entry
+
+			-- Line 3 (optional): lock or prune reason
+			if entry.is_locked and entry.lock_reason then
+				local line3 = B:push({
+					{ "       Locked: ", "GitflowWorktreeLocked" },
+					{ entry.lock_reason, "GitflowMeta" },
+				})
+				line_entries[line3] = entry
+			elseif entry.is_prunable and entry.prune_reason then
+				local line3 = B:push({
+					{ "       Prunable: ", "GitflowWorktreePrunable" },
+					{ entry.prune_reason, "GitflowMeta" },
+				})
+				line_entries[line3] = entry
+			end
+
+			B:blank()
 		end
 	end
 
@@ -298,6 +357,90 @@ local function render(entries)
 	end
 	B:apply(bufnr, WORKTREE_HIGHLIGHT_NS)
 	components.cursorline(M.state.winid, true)
+end
+
+---Fire async enrichment for each non-bare worktree: commit subject + relative
+---time (one git-log call) and dirty status (git-status --porcelain). Both
+---calls are batched in parallel; a single re-render fires once ALL complete.
+---A generation counter discards results from superseded refreshes.
+---@param entries GitflowWorktreeEntry[]
+local function enrich_entries(entries)
+	local enrichable = {}
+	for _, entry in ipairs(entries) do
+		if not entry.is_bare
+			and entry.path ~= ""
+			and vim.fn.isdirectory(entry.path) == 1
+		then
+			enrichable[#enrichable + 1] = entry
+		end
+	end
+
+	if #enrichable == 0 then
+		return
+	end
+
+	M.state.enrich_gen = M.state.enrich_gen + 1
+	local gen = M.state.enrich_gen
+
+	local pending = #enrichable * 2
+	local enrichment = {}
+	for _, entry in ipairs(enrichable) do
+		enrichment[entry.path] = {}
+	end
+
+	local function done()
+		pending = pending - 1
+		if pending > 0 or gen ~= M.state.enrich_gen then
+			return
+		end
+		M.state.enrichment = enrichment
+		-- Re-render with the same entries list — card structure is stable
+		-- (same line count per entry) so cursor position is preserved.
+		if M.is_open() then
+			render(entries)
+		end
+	end
+
+	for _, entry in ipairs(enrichable) do
+		-- Commit subject + relative time in one log call.
+		git.git(
+			{ "log", "-1", "--format=%s%x1F%ar" },
+			{ cwd = entry.path },
+			function(result)
+				if result.code == 0 then
+					local out = vim.trim(result.stdout or "")
+					if out ~= "" then
+						local sep = out:find("\x1F", 1, true)
+						local subject, rel_time
+						if sep then
+							subject = out:sub(1, sep - 1)
+							rel_time = vim.trim(out:sub(sep + 1))
+						else
+							subject = out
+						end
+						-- Guard against multi-line output (e.g. test stubs).
+						enrichment[entry.path].subject =
+							subject and subject:match("^([^\n]*)")
+						enrichment[entry.path].rel_time = rel_time
+					end
+				end
+				done()
+			end
+		)
+
+		-- Dirty indicator: any output from --porcelain means uncommitted changes.
+		git.git(
+			{ "status", "--porcelain" },
+			{ cwd = entry.path },
+			function(result)
+				if result.code == 0 then
+					enrichment[entry.path].is_dirty =
+						vim.trim(result.stdout or "") ~= ""
+				end
+				done()
+			end
+		)
+	end
 end
 
 ---@return GitflowWorktreeEntry|nil
@@ -317,7 +460,6 @@ function M.open(cfg)
 	ensure_window(cfg)
 	render_loading()
 
-	-- Keep the list fresh when worktrees change via commands / other panels.
 	vim.api.nvim_clear_autocmds({ group = WORKTREE_AUGROUP })
 	vim.api.nvim_create_autocmd("User", {
 		group = WORKTREE_AUGROUP,
@@ -338,13 +480,19 @@ function M.refresh()
 		return
 	end
 
+	-- Invalidate any in-flight enrichment from the previous load.
+	M.state.enrich_gen = M.state.enrich_gen + 1
+	M.state.enrichment = {}
+
 	git_worktree.list({}, function(err, entries)
 		if err then
 			utils.notify(err, vim.log.levels.ERROR)
 			render_error(err)
 			return
 		end
-		render(entries or {})
+		local list = entries or {}
+		render(list)
+		enrich_entries(list)
 	end)
 end
 
@@ -425,7 +573,6 @@ function M.add_worktree()
 		return
 	end
 
-	-- 1) Where the worktree lives on disk.
 	ui.input.prompt(
 		{ prompt = "New worktree path: " },
 		function(path)
@@ -434,11 +581,7 @@ function M.add_worktree()
 			end
 			path = vim.trim(path)
 
-			-- 2) Pick the base ref from a searchable list of branches.
 			pick_base_ref("Base worktree on", function(base)
-				-- 3) Optionally create a new branch from that base. Leaving
-				--    the name empty checks the base ref out directly.
-				--    (<Esc> aborts — on_confirm only fires on a typed value.)
 				ui.input.prompt(
 					{
 						prompt = ("New branch name (empty = check out '%s'): ")
@@ -474,8 +617,6 @@ function M.remove_under_cursor(force)
 		return
 	end
 
-	-- A locked worktree can't be removed without force; nudge the user to
-	-- unlock (L) or force (D) rather than letting git error out.
 	if entry.is_locked and not force then
 		utils.notify(
 			"Worktree is locked — press L to unlock, or D to force-remove",
@@ -536,7 +677,6 @@ function M.toggle_lock_under_cursor()
 		return
 	end
 
-	-- Locking: offer an optional reason.
 	ui.input.prompt(
 		{ prompt = "Lock reason (optional): " },
 		function(reason)
@@ -634,8 +774,6 @@ function M.switch_under_cursor()
 		return
 	end
 
-	-- Change Neovim's working directory so subsequent gitflow operations
-	-- (which resolve the repo via cwd) target the selected worktree.
 	local ok = pcall(vim.cmd, "cd " .. vim.fn.fnameescape(entry.path))
 	if not ok then
 		utils.notify(
@@ -671,6 +809,7 @@ function M.close()
 	M.state.bufnr = nil
 	M.state.winid = nil
 	M.state.line_entries = {}
+	M.state.enrichment = {}
 end
 
 ---@return boolean

--- a/tests/e2e/rebase_spec.lua
+++ b/tests/e2e/rebase_spec.lua
@@ -87,8 +87,8 @@ T.run_suite("Interactive Rebase Panel", {
 	["parse_commits returns entries with pick default action"] = function()
 		local git_rebase = require("gitflow.git.rebase")
 		local output = table.concat({
-			"abc1234567890123456789012345678901234567\tfirst",
-			"def5678901234567890123456789012345678901\tsecond",
+			"abc1234567890123456789012345678901234567\tJohn Doe\t3 days ago\tfirst",
+			"def5678901234567890123456789012345678901\tJane Smith\t1 hour ago\tsecond",
 		}, "\n")
 		local entries = git_rebase.parse_commits(output)
 		T.assert_equals(#entries, 2, "should parse 2 entries")
@@ -99,6 +99,14 @@ T.run_suite("Interactive Rebase Panel", {
 		T.assert_equals(
 			entries[1].short_sha, "abc1234",
 			"short_sha should be 7 chars"
+		)
+		T.assert_equals(
+			entries[1].author, "John Doe",
+			"author should be parsed"
+		)
+		T.assert_equals(
+			entries[1].relative_time, "3 days ago",
+			"relative_time should be parsed"
 		)
 	end,
 


### PR DESCRIPTION
Each worktree now renders as a 2–3 line card matching the PR/issue style:
- Line 1: icon + branch/ref + [current] [locked] [prunable] ~ badges
- Line 2 (dim): short-sha · commit subject · relative time · ~/path
- Line 3 (optional): lock reason or prune reason text

Commit info and dirty status are loaded lazily in a parallel async batch after the initial list renders, so the panel appears immediately and enriches within ~100ms. A generation counter discards stale callbacks from superseded refreshes.

All card lines map to their worktree entry in line_entries, so actions (remove, lock, move, switch) work from any line within a card.

Adds GitflowWorktreeDirty highlight (linked to DiagnosticWarn).