### PR TITLE
surface the destructive X key; split-layout hints for log/reflog/tag

### DIFF
--- a/.dm-knowledge/gf-status-hints.md
+++ b/.dm-knowledge/gf-status-hints.md
@@ -1,0 +1,1 @@
+- **[convention]** status.lua's X (discard uncommitted changes) already confirms via ui.input.confirm defaulting to Cancel before running git restore/checkout/clean — verified by capturing vim.fn.confirm's default_choice arg in scripts/test_stage2.lua. It was just missing from the footer/split hints; not a missing-confirm bug.  _(2026-07-20T14:16:12Z)_

--- a/lua/gitflow/panels/log.lua
+++ b/lua/gitflow/panels/log.lua
@@ -19,6 +19,13 @@ local components = require("gitflow.ui.components")
 local M = {}
 local LOG_FLOAT_TITLE = "  Gitflow Log  "
 local LOG_FLOAT_FOOTER = " <CR> review commit · V range select · r refresh · q close "
+-- Split-layout counterpart of LOG_FLOAT_FOOTER; keep the two in sync.
+local LOG_HINTS = {
+	{ "<CR>", "review commit" },
+	{ "V", "range select" },
+	{ "r", "refresh" },
+	{ "q", "close" },
+}
 local LOG_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_log_hl")
 
 ---@type GitflowLogPanelState
@@ -159,7 +166,10 @@ local function render(entries, current_branch)
 		end
 	end
 
-	B:blank()
+	-- In-buffer hints for split layout (floats advertise the same keys in
+	-- their window footer). Kept above the branch footer so the final line
+	-- stays the exact "Current branch: <branch>" string tests rely on.
+	components.split_hint_bar(B, render_opts, LOG_HINTS)
 	components.branch_footer(B, current_branch)
 
 	ui.buffer.update("log", B.lines)

--- a/lua/gitflow/panels/reflog.lua
+++ b/lua/gitflow/panels/reflog.lua
@@ -19,6 +19,14 @@ local REFLOG_HIGHLIGHT_NS =
 	vim.api.nvim_create_namespace("gitflow_reflog_hl")
 local REFLOG_FLOAT_FOOTER =
 	" <CR> checkout · 1-9 quick checkout · R reset · r refresh · q close "
+-- Split-layout counterpart of REFLOG_FLOAT_FOOTER; keep the two in sync.
+local REFLOG_HINTS = {
+	{ "<CR>", "checkout" },
+	{ "1-9", "quick checkout" },
+	{ "R", "reset" },
+	{ "r", "refresh" },
+	{ "q", "close" },
+}
 
 ---@type GitflowReflogPanelState
 M.state = {
@@ -196,6 +204,10 @@ local function render(entries, current_branch)
 		end
 	end
 
+	-- In-buffer hints for split layout (floats advertise the same keys in
+	-- their window footer).
+	components.split_hint_bar(B, render_opts, REFLOG_HINTS)
+
 	ui.buffer.update("reflog", B.lines)
 	M.state.line_entries = line_entries
 
@@ -235,12 +247,11 @@ end
 
 ---@param entry GitflowReflogEntry
 local function execute_checkout(entry)
-	local confirmed = vim.fn.confirm(
+	local confirmed = ui.input.confirm(
 		("Checkout %s? This will detach HEAD."):format(
 			entry.short_sha
-		),
-		"&Yes\n&No", 2
-	) == 1
+		)
+	)
 	if not confirmed then
 		return
 	end
@@ -320,9 +331,12 @@ function M.reset_under_cursor()
 		return
 	end
 
-	local choice = vim.fn.confirm(
+	local _, choice = ui.input.confirm(
 		("Reset to %s?"):format(entry.short_sha),
-		"&Soft\n&Mixed\n&Hard\n&Cancel", 4
+		{
+			choices = { "&Soft", "&Mixed", "&Hard", "&Cancel" },
+			default_choice = 4,
+		}
 	)
 	if choice == 0 or choice == 4 then
 		return

--- a/lua/gitflow/panels/status.lua
+++ b/lua/gitflow/panels/status.lua
@@ -45,7 +45,7 @@ local STATUS_HIGHLIGHT_NS = vim.api.nvim_create_namespace("gitflow_status_hl")
 local STATUS_FLOAT_TITLE = "  Gitflow Status  "
 local STATUS_NO_UPSTREAM_HEADER = "Outgoing / Incoming"
 local STATUS_FLOAT_FOOTER = " s/u stage · V then s/u batch · a/A all · cc commit"
-	.. " · dd diff · cx conflict · p push · r refresh · q close "
+	.. " · dd diff · cx conflict · X discard changes · p push · r refresh · q close "
 -- Compact in-buffer hints for split layout (floats use the footer above).
 local STATUS_HINTS = {
 	{ "s/u", "stage/unstage" },
@@ -53,6 +53,7 @@ local STATUS_HINTS = {
 	{ "<CR>", "open" },
 	{ "cc", "commit" },
 	{ "dd", "diff" },
+	{ "X", "discard changes" },
 	{ "p", "push" },
 	{ "r", "refresh" },
 	{ "q", "close" },

--- a/lua/gitflow/panels/tag.lua
+++ b/lua/gitflow/panels/tag.lua
@@ -17,6 +17,15 @@ local M = {}
 local TAG_FLOAT_TITLE = "  Gitflow Tags  "
 local TAG_FLOAT_FOOTER =
 	" c create · D delete · X remote del · P push · r refresh · q close "
+-- Split-layout counterpart of TAG_FLOAT_FOOTER; keep the two in sync.
+local TAG_HINTS = {
+	{ "c", "create" },
+	{ "D", "delete" },
+	{ "X", "remote del" },
+	{ "P", "push" },
+	{ "r", "refresh" },
+	{ "q", "close" },
+}
 local TAG_HIGHLIGHT_NS =
 	vim.api.nvim_create_namespace("gitflow_tag_hl")
 
@@ -164,6 +173,10 @@ local function render(entries, current_branch)
 			line_entries[line_no] = entry
 		end
 	end
+
+	-- In-buffer hints for split layout (floats advertise the same keys in
+	-- their window footer).
+	components.split_hint_bar(B, render_opts, TAG_HINTS)
 
 	ui.buffer.update("tag", B.lines)
 	M.state.line_entries = line_entries

--- a/scripts/test_stage2.lua
+++ b/scripts/test_stage2.lua
@@ -400,6 +400,54 @@ assert_deep_equals(
 	"revert should restore tracked file content"
 )
 
+-- X is destructive and irreversible, so the confirm gate matters more than
+-- the hint text: prove it actually defaults to Cancel (simulating <CR> with
+-- no explicit choice) and that the default leaves the file untouched.
+write_file(repo_dir .. "/tracked.txt", { "alpha", "beta", "gamma", "uncommitted" })
+status_panel.refresh()
+local decline_ready = vim.wait(5000, function()
+	if not status_panel.state.bufnr then
+		return false
+	end
+	local lines = vim.api.nvim_buf_get_lines(status_panel.state.bufnr, 0, -1, false)
+	local header = find_line(lines, "Unstaged")
+	return header ~= nil and find_line(lines, "tracked.txt", header + 1) ~= nil
+end, 25)
+assert_true(decline_ready, "status panel should show the new uncommitted change as unstaged")
+
+local decline_lines = vim.api.nvim_buf_get_lines(status_panel.state.bufnr, 0, -1, false)
+local decline_unstaged_header = find_line(decline_lines, "Unstaged")
+local decline_tracked_line = find_line(decline_lines, "tracked.txt", decline_unstaged_header + 1)
+assert_true(decline_tracked_line ~= nil, "unstaged tracked file should be visible")
+
+local captured_message, captured_default_choice = nil, nil
+local decline_confirm = vim.fn.confirm
+vim.fn.confirm = function(message, _, default_choice)
+	captured_message = message
+	captured_default_choice = default_choice
+	-- Simulate pressing <CR> without picking a choice: real vim.fn.confirm
+	-- returns the dialog's own default in that case.
+	return default_choice
+end
+vim.api.nvim_win_set_cursor(status_panel.state.winid, { decline_tracked_line, 0 })
+status_panel.revert_under_cursor()
+vim.wait(300)
+vim.fn.confirm = decline_confirm
+
+assert_true(
+	type(captured_message) == "string" and captured_message:find("tracked.txt", 1, true) ~= nil,
+	"revert should still prompt for confirmation before discarding"
+)
+assert_equals(
+	captured_default_choice, 2,
+	"revert confirm must default to Cancel (index 2), not Revert"
+)
+assert_deep_equals(
+	vim.fn.readfile(repo_dir .. "/tracked.txt"),
+	{ "alpha", "beta", "gamma", "uncommitted" },
+	"declining (or dismissing) the revert confirm must leave uncommitted changes intact"
+)
+
 local branch_name = vim.trim(run_git(repo_dir, { "rev-parse", "--abbrev-ref", "HEAD" }))
 local remote_dir = vim.fn.tempname()
 run_git(repo_dir, { "init", "--bare", remote_dir })

--- a/tests/e2e/keybindings_spec.lua
+++ b/tests/e2e/keybindings_spec.lua
@@ -176,7 +176,7 @@ T.run_suite("E2E: Keybinding Verification", {
 		local bufnr = ui.buffer.get("status")
 		T.assert_true(bufnr ~= nil, "status buffer should exist")
 
-		local expected_keys = { "s", "u", "a", "A", "r", "q" }
+		local expected_keys = { "s", "u", "a", "A", "X", "r", "q" }
 		for _, key in ipairs(expected_keys) do
 			local m = find_buf_map(bufnr, key)
 			T.assert_true(

--- a/tests/e2e/open_ui_spec.lua
+++ b/tests/e2e/open_ui_spec.lua
@@ -212,6 +212,77 @@ T.run_suite("E2E: UI Initialization & Panel Open/Close", {
 		status.close()
 	end,
 
+	-- `X` discards uncommitted changes irreversibly; it must be advertised
+	-- (worded as destructive) in both the float footer and the split hints,
+	-- not just bound silently.
+	["status panel advertises X as a destructive discard in both layouts"] = function()
+		local status = require("gitflow.panels.status")
+		local gitflow = require("gitflow")
+
+		---@param footer any  string or [text, hl] chunk list
+		---@return string
+		local function footer_text(footer)
+			if type(footer) == "string" then
+				return footer
+			end
+			if type(footer) ~= "table" then
+				return tostring(footer or "")
+			end
+			local parts = {}
+			for _, chunk in ipairs(footer) do
+				parts[#parts + 1] = type(chunk) == "table"
+					and tostring(chunk[1] or "") or tostring(chunk)
+			end
+			return table.concat(parts)
+		end
+
+		gitflow.setup({
+			ui = {
+				default_layout = "float",
+				split = { orientation = "vertical", size = 40 },
+			},
+		})
+		T.exec_command("Gitflow status")
+		T.drain_jobs(3000)
+
+		local float_winid = status.state.winid
+		T.assert_true(
+			float_winid ~= nil and vim.api.nvim_win_is_valid(float_winid),
+			"status float window should be valid"
+		)
+		local float_footer = footer_text(
+			vim.api.nvim_win_get_config(float_winid).footer
+		)
+		T.assert_contains(
+			float_footer, "X",
+			"status float footer should advertise the X key"
+		)
+		T.assert_contains(
+			float_footer, "discard",
+			"status float footer should word X as destructive (discard), not a bare verb"
+		)
+		status.close()
+
+		gitflow.setup({
+			ui = {
+				default_layout = "split",
+				split = { orientation = "vertical", size = 40 },
+			},
+		})
+		T.exec_command("Gitflow status")
+		T.drain_jobs(3000)
+
+		local split_bufnr = ui.buffer.get("status")
+		T.assert_true(
+			split_bufnr ~= nil, "status buffer should exist in split layout"
+		)
+		T.assert_true(
+			T.buf_find_line(split_bufnr, "discard") ~= nil,
+			"status split-layout hints should advertise X as a destructive discard"
+		)
+		status.close()
+	end,
+
 	-- ── Diff panel open/close ───────────────────────────────────────────
 
 	["diff panel opens and creates buffer"] = function()
@@ -268,6 +339,25 @@ T.run_suite("E2E: UI Initialization & Panel Open/Close", {
 		T.assert_true(
 			bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr),
 			"log buffer should exist after :Gitflow log"
+		)
+
+		log_panel.close()
+	end,
+
+	-- Split is the test-suite default layout; this proves the log panel's
+	-- split hint bar actually renders (not just that opening it doesn't
+	-- throw — a *_HINTS table can be deleted while its call site remains,
+	-- which only breaks the split path since the float path returns early).
+	["log panel renders keybind hints in split layout"] = function()
+		local log_panel = require("gitflow.panels.log")
+		T.exec_command("Gitflow log")
+		T.drain_jobs(3000)
+
+		local bufnr = ui.buffer.get("log")
+		T.assert_true(bufnr ~= nil, "log buffer should exist")
+		T.assert_true(
+			T.buf_find_line(bufnr, "review commit") ~= nil,
+			"log panel split layout should render its keybind hints"
 		)
 
 		log_panel.close()

--- a/tests/e2e/reflog_spec.lua
+++ b/tests/e2e/reflog_spec.lua
@@ -110,6 +110,27 @@ T.run_suite("E2E: Reflog Panel", {
 		reflog_panel.close()
 	end,
 
+	-- Split is the test-suite default layout; this proves the reflog
+	-- panel's split hint bar actually renders (not just that opening it
+	-- doesn't throw — a *_HINTS table can be deleted while its call site
+	-- remains, which only breaks the split path since the float path
+	-- returns early).
+	["reflog panel renders keybind hints in split layout"] = function()
+		local reflog_panel = require("gitflow.panels.reflog")
+		commands.dispatch({ "reflog" }, cfg)
+		T.drain_jobs(3000)
+
+		local bufnr = ui.buffer.get("reflog")
+		T.assert_true(bufnr ~= nil, "reflog buffer should exist")
+		local lines = T.buf_lines(bufnr)
+		T.assert_true(
+			T.find_line(lines, "quick checkout") ~= nil,
+			"reflog panel split layout should render its keybind hints"
+		)
+
+		reflog_panel.close()
+	end,
+
 	-- ── Panel content ───────────────────────────────────────────────
 
 	["reflog panel renders entries from stub"] = function()

--- a/tests/e2e/tag_spec.lua
+++ b/tests/e2e/tag_spec.lua
@@ -102,6 +102,26 @@ T.run_suite("E2E: Tag Panel", {
 		tag_panel.close()
 	end,
 
+	-- Split is the test-suite default layout; this proves the tag panel's
+	-- split hint bar actually renders (not just that opening it doesn't
+	-- throw — a *_HINTS table can be deleted while its call site remains,
+	-- which only breaks the split path since the float path returns early).
+	["tag panel renders keybind hints in split layout"] = function()
+		local tag_panel = require("gitflow.panels.tag")
+		commands.dispatch({ "tag", "list" }, cfg)
+		T.drain_jobs(3000)
+
+		local bufnr = ui.buffer.get("tag")
+		T.assert_true(bufnr ~= nil, "tag buffer should exist")
+		local lines = T.buf_lines(bufnr)
+		T.assert_true(
+			T.find_line(lines, "remote del") ~= nil,
+			"tag panel split layout should render its keybind hints"
+		)
+
+		tag_panel.close()
+	end,
+
 	-- ── Panel content ───────────────────────────────────────────────
 
 	["tag panel renders tag entries from stub"] = function()


### PR DESCRIPTION
**`X` discards changes and appeared in no footer or hint line.** Checked safety first: `revert_under_cursor` already gates the destructive `git restore`/`checkout`/`clean -f` sequence behind `ui.input.confirm` with `default_choice = 2` (Cancel), so this is a discoverability defect, not a missing confirm. Added to `STATUS_FLOAT_FOOTER` and `STATUS_HINTS`, worded `discard changes` to match the repo's existing severity-signaling convention (`D force delete`, `H hard reset`) rather than a bare verb.

New stage-2 test stubs `vim.fn.confirm` to capture its arguments and simulates Enter with no explicit choice against a real git repo, proving the default really is index 2 (Cancel) and the file stays untouched.

**Split-layout hints for `log`, `reflog`, `tag`** — three of the panels that render none in split mode, following `conflict.lua`'s `*_HINTS` + `components.split_hint_bar` pattern.

Worth recording: the historical trap named in this repo's knowledge was reproduced directly. Deleting `LOG_HINTS` while leaving its call site throws `bad argument #1 to 'ipairs' (table expected, got nil)` — **and the pre-existing "opens without crash" test still passed**, because the error occurs inside a `vim.schedule` callback that Neovim reports to stderr and swallows rather than propagating into the test's `pcall`. That is precisely how the original regression shipped. The new tests assert the hint text actually renders in split mode, so they do fail on the broken shape.

**`reflog.lua` confirm-wrapper migration** — both raw `vim.fn.confirm` sites moved to the canonical `ui.input.confirm`. Semantics verified byte-identical by reading the wrapper: the binary checkout confirm uses the wrapper's own defaults; the 4-way reset confirm reuses the tuple-return pattern already established at `reset.lua:268`, keeping the same choices string and `default_choice = 4`. Destructive `R` reset still defaults to Cancel.

Risk: low. Verified: both suites (21 E2E specs + full CI stage list) green before and after. Each of the 4 source changes reverted individually and its corresponding new test confirmed to fail; restored and reconfirmed green.
